### PR TITLE
Hidden lgtm.yml file to enable C/C++ analysis of USBGuard on lgtm.com

### DIFF
--- a/.lgtm.yml
+++ b/.lgtm.yml
@@ -5,6 +5,10 @@
 extraction:
   cpp:
     prepare:
+      # Most Debian/Ubuntu package dependencies 
+      # are automatically detected, but this one
+      # is not. The team at lgtm.com are looking
+      # into it.
       packages:
         - libdbus-glib-1-dev
     

--- a/.lgtm.yml
+++ b/.lgtm.yml
@@ -1,0 +1,15 @@
+# lgtm.yml configuration file for C/C++ analysis
+# of USBGuard on lgtm.com:
+# https://lgtm.com/projects/g/USBGuard/usbguard
+
+extraction:
+  cpp:
+    prepare:
+      packages:
+        - libdbus-glib-1-dev
+    
+    after_prepare:
+      - ./autogen.sh
+
+    configure:
+      command: ./configure --with-bundled-pegtl


### PR DESCRIPTION
I noticed you added automatic code review by lgtm.com for USBGuard — glad you're enjoying our analyses! I've just added USBGuard to the C/C++ analysis beta on lgtm.com. The file in this PR contains a couple of build hints for lgtm.

This configuration is currently being used by lgtm.com for C/C++ analysis of USBGuard. Results for C/C++ have just appeared: https://lgtm.com/projects/g/USBGuard/usbguard (historical analysis is in progress).

The lgtm.com analysis will automatically pick up any changes to this file in the USBGuard repository; that's handy if your build procedure changes in the future.

(Full disclosure: I'm part of the team behind lgtm.com :slightly_smiling_face:)