### PR TITLE
Changes that help build usbguard with clang++ and with less dependencies.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -52,6 +52,7 @@ DISTCLEANFILES=\
 
 CLEANFILES=
 
+if DOCS_ENABLED
 man_ADOC_FILES=\
 	doc/man/usbguard.1.adoc \
 	doc/man/usbguard-dbus.8.adoc \
@@ -59,6 +60,9 @@ man_ADOC_FILES=\
 	doc/man/usbguard-daemon.8.adoc \
 	doc/man/usbguard-daemon.conf.5.adoc \
 	doc/man/usbguard-rules.conf.5.adoc
+else
+man_ADOC_FILES=
+endif
 
 man_ROFF_FILES=\
 	$(man_ADOC_FILES:.adoc=.roff)
@@ -127,6 +131,7 @@ install-systemd-service:
 uninstall-systemd-service:
 endif
 
+if DOCS_ENABLED
 man8_MANS=\
 	$(top_builddir)/doc/man/usbguard-daemon.8
 
@@ -136,6 +141,11 @@ man5_MANS=\
 
 man1_MANS=\
 	$(top_builddir)/doc/man/usbguard.1
+else
+man8_MANS=
+man5_MANS=
+man1_MANS=
+endif
 
 AM_CPPFLAGS=\
 	-I$(top_srcdir)/src \
@@ -406,8 +416,10 @@ usbguard_rule_parser_LDADD=\
 if DBUS_ENABLED
 sbin_PROGRAMS+= usbguard-dbus
 
+if DOCS_ENABLED
 man8_MANS+=\
 	$(top_builddir)/doc/man/usbguard-dbus.8
+endif
 
 BUILT_SOURCES+=\
 	src/DBus/DBusInterface.xml.cstr \
@@ -558,8 +570,10 @@ desktop_DATA = $(top_builddir)/src/GUI.Qt/usbguard-applet-qt.desktop
 appicondir = $(datadir)/icons/hicolor/scalable/apps
 appicon_DATA = src/GUI.Qt/resources/usbguard-icon.svg
 
+if DOCS_ENABLED
 man1_MANS +=\
 	$(top_builddir)/doc/man/usbguard-applet-qt.1
+endif
 
 BUILT_SOURCES+=\
 	$(usbguard_applet_qt_UIHEADERS) \

--- a/configure.ac
+++ b/configure.ac
@@ -555,11 +555,11 @@ if test "x$enable_tsan" = xyes; then
 fi
 
 #
-# Require asciidoctor.
+# Check whether asciidoctor is present.
 #
 AC_CHECK_PROGS(ASCIIDOCTOR, [asciidoctor])
 if test -z "$ASCIIDOCTOR"; then
-  AC_MSG_FAILURE([Unable to find documentation generator (asciidoctor)])
+  AC_MSG_WARN([Unable to find documentation generator (asciidoctor). Documentation will not be generated.])
 fi
 
 #
@@ -691,6 +691,7 @@ AC_SUBST([BASH_COMPLETION_DIR], $bash_completion_dir)
 AM_CONDITIONAL([SYSTEMD_SUPPORT_ENABLED], [test "x$systemd" = xyes ])
 AM_CONDITIONAL([GUI_QT_ENABLED], [test "x$build_gui_qt" = xyes ])
 AM_CONDITIONAL([DBUS_ENABLED], [test "x$with_dbus" = xyes ])
+AM_CONDITIONAL([DOCS_ENABLED], [! test -z "$ASCIIDOCTOR" ])
 AM_CONDITIONAL([POLICYKIT_ENABLED], [test "x$with_polkit" = xyes])
 AM_CONDITIONAL([FULL_TEST_SUITE_ENABLED], [test "x$full_test_suite" = xyes])
 AM_CONDITIONAL([BASH_COMPLETION_ENABLED], [test "x$bash_completion" != xno])

--- a/src/Library/public/usbguard/ConfigFile.cpp
+++ b/src/Library/public/usbguard/ConfigFile.cpp
@@ -26,7 +26,7 @@
 namespace usbguard
 {
   ConfigFile::ConfigFile(const std::vector<std::string>& known_names)
-    : d_pointer(make_unique<ConfigFilePrivate>(*this, known_names))
+    : d_pointer(usbguard::make_unique<ConfigFilePrivate>(*this, known_names))
   {
   }
 

--- a/src/Library/public/usbguard/Device.cpp
+++ b/src/Library/public/usbguard/Device.cpp
@@ -26,14 +26,14 @@
 namespace usbguard
 {
   Device::Device(DeviceManager& manager)
-    : d_pointer(make_unique<DevicePrivate>(*this, manager))
+    : d_pointer(usbguard::make_unique<DevicePrivate>(*this, manager))
   {
   }
 
   Device::~Device() = default;
 
   Device::Device(const Device& rhs)
-    : d_pointer(make_unique<DevicePrivate>(*this, *rhs.d_pointer))
+    : d_pointer(usbguard::make_unique<DevicePrivate>(*this, *rhs.d_pointer))
   {
   }
 

--- a/src/Library/public/usbguard/DeviceManager.cpp
+++ b/src/Library/public/usbguard/DeviceManager.cpp
@@ -69,12 +69,12 @@ namespace usbguard
   }
 
   DeviceManager::DeviceManager(DeviceManagerHooks& hooks)
-    : d_pointer(make_unique<DeviceManagerPrivate>(*this, hooks))
+    : d_pointer(usbguard::make_unique<DeviceManagerPrivate>(*this, hooks))
   {
   }
 
   DeviceManager::DeviceManager(const DeviceManager& rhs)
-    : d_pointer(make_unique<DeviceManagerPrivate>(*this, *rhs.d_pointer))
+    : d_pointer(usbguard::make_unique<DeviceManagerPrivate>(*this, *rhs.d_pointer))
   {
   }
 

--- a/src/Library/public/usbguard/IPCClient.cpp
+++ b/src/Library/public/usbguard/IPCClient.cpp
@@ -26,7 +26,7 @@
 namespace usbguard
 {
   IPCClient::IPCClient(bool connected)
-    : d_pointer(make_unique<IPCClientPrivate>(*this, connected))
+    : d_pointer(usbguard::make_unique<IPCClientPrivate>(*this, connected))
   {
   }
 

--- a/src/Library/public/usbguard/IPCServer.cpp
+++ b/src/Library/public/usbguard/IPCServer.cpp
@@ -251,7 +251,7 @@ namespace usbguard
   }
 
   IPCServer::IPCServer()
-    : d_pointer(make_unique<IPCServerPrivate>(*this))
+    : d_pointer(usbguard::make_unique<IPCServerPrivate>(*this))
   {
   }
 

--- a/src/Library/public/usbguard/Rule.cpp
+++ b/src/Library/public/usbguard/Rule.cpp
@@ -38,14 +38,14 @@ namespace usbguard
   const uint32_t Rule::ImplicitID = std::numeric_limits<uint32_t>::max() - 1;
 
   Rule::Rule()
-    : d_pointer(make_unique<RulePrivate>(*this))
+    : d_pointer(usbguard::make_unique<RulePrivate>(*this))
   {
   }
 
   Rule::~Rule() = default;
 
   Rule::Rule(const Rule& rhs)
-    : d_pointer(make_unique<RulePrivate>(*this, *rhs.d_pointer))
+    : d_pointer(usbguard::make_unique<RulePrivate>(*this, *rhs.d_pointer))
   {
   }
 

--- a/src/Library/public/usbguard/RuleSet.cpp
+++ b/src/Library/public/usbguard/RuleSet.cpp
@@ -27,14 +27,14 @@
 namespace usbguard
 {
   RuleSet::RuleSet(Interface* const interface_ptr)
-    : d_pointer(make_unique<RuleSetPrivate>(*this, interface_ptr))
+    : d_pointer(usbguard::make_unique<RuleSetPrivate>(*this, interface_ptr))
   {
   }
 
   RuleSet::~RuleSet() = default;
 
   RuleSet::RuleSet(const RuleSet& rhs)
-    : d_pointer(make_unique<RuleSetPrivate>(*this, *rhs.d_pointer))
+    : d_pointer(usbguard::make_unique<RuleSetPrivate>(*this, *rhs.d_pointer))
   {
   }
 


### PR DESCRIPTION
I am looking at using usbguard for a project, but some changes will need needed to get it to work as needed. I figured I would see if you would take these patches since they should help out others using usbguard if they have similar requirements.

There is some chance I may submit a followup pull request to try and break the dependency on libstdc++ so that usbguard builds both either libc++ or libstdc++ as desired.