### PR TITLE
Ignore empty lines in usbguard-rule-parser

### DIFF
--- a/src/CLI/usbguard-rule-parser.cpp
+++ b/src/CLI/usbguard-rule-parser.cpp
@@ -100,12 +100,12 @@ int main(int argc, char** argv)
       while (stream.good()) {
         rule_spec.clear();
         std::getline(stream, rule_spec);
+        ++line;
 
         if (rule_spec.empty()) {
-          break;
+          continue;
         }
 
-        ++line;
         std::cout << "INPUT: " << rule_spec << std::endl;
         const usbguard::Rule rule = usbguard::parseRuleFromString(rule_spec, rule_file, line, trace);
         std::cout << "OUTPUT: " << rule.toString() << std::endl;

--- a/src/Tests/Makefile.am
+++ b/src/Tests/Makefile.am
@@ -33,6 +33,7 @@ EXTRA_DIST=\
 	$(top_srcdir)/src/Tests/Rules/test-rules.sh \
 	$(top_srcdir)/src/Tests/Rules/test-rules.good \
 	$(top_srcdir)/src/Tests/Rules/test-rules.bad \
+	$(top_srcdir)/src/Tests/Rules/test-rules.file \
 	$(top_srcdir)/src/Tests/UseCase/000_executable.sh \
 	$(top_srcdir)/src/Tests/UseCase/001_cli_policy.sh \
 	$(top_srcdir)/src/Tests/UseCase/002_cli_devices.sh \

--- a/src/Tests/Rules/test-rules.file
+++ b/src/Tests/Rules/test-rules.file
@@ -1,0 +1,11 @@
+# This file should have an empty line before the first rule
+# to be meaningful in the context of the test suite.
+
+# And then after that blank line we should get at least some
+# results from the output of usbguard-rule-parser.
+reject with-interface one-of { e5:*:* 2A:*:* AC:c7:* 4B:*:* f2:*:* }  if equals-ordered { true false !true false }
+#
+# this is a comment followed by an empty line
+
+reject with-interface one-of { e6:*:* } # comment about this rule
+ # reject with-interface one-of { e6:*:* }

--- a/src/Tests/Rules/test-rules.sh
+++ b/src/Tests/Rules/test-rules.sh
@@ -17,52 +17,40 @@
 #
 # Authors: Daniel Kopecek <dkopecek@redhat.com>
 #
-# Usage: test-rules.sh <parser-binary-path> <test-data-dir>
-#        test-rules.sh
+# Usage: test-rules.sh [<parser-binary-path>] [<test-data-dir>]
 #
 
-if [ -z "$1" -o -z "$2" ]; then
-  PARSER="$builddir/usbguard-rule-parser"
-  DATADIR="$srcdir/src/Tests/Rules/"
-else
-  USBGUARD="$1"
-  DATADIR="$2"
-fi
+PARSER=${1:-"$builddir/usbguard-rule-parser"}
+DATADIR=${2:-"$srcdir/src/Tests/Rules/"}
 
-#TEMPDIR="$(mktemp -d --tmpdir usbguard-test-descriptor-parser.XXXXXX)"
 RETVAL=0
-export IFS=
+IFS=' 	
+' # Explicit default IFS (SP HT LN)
 
 echo
 echo "Parsing GOOD rules:"
 echo "###################"
 echo
 while read -r rule; do
-  $PARSER "$rule"
-  if [ $? -ne 0 ]; then
+  if ! $PARSER "$rule"; then
     echo "============="
     echo "FAILED: $rule"
     echo "^^^^^^^^^^^^^"
     RETVAL=1
   fi
-done <<EOF
-$(cat $DATADIR/test-rules.good)
-EOF
+done <"$DATADIR/test-rules.good"
 
 echo
 echo "Parsing BAD rules:"
 echo "##################"
 echo
 while read -r rule; do
-  $PARSER "$rule"
-  if [ $? -eq 0 ]; then
+  if $PARSER "$rule"; then
     echo "============="
     echo "FAILED: $rule"
     echo "^^^^^^^^^^^^^"
     RETVAL=1
   fi
-done <<EOF
-$(cat $DATADIR/test-rules.bad)
-EOF
+done <"$DATADIR/test-rules.bad"
 
 exit $RETVAL

--- a/src/Tests/Rules/test-rules.sh
+++ b/src/Tests/Rules/test-rules.sh
@@ -53,4 +53,25 @@ while read -r rule; do
   fi
 done <"$DATADIR/test-rules.bad"
 
+echo
+echo "Parsing rules file:"
+echo "###################"
+echo
+$PARSER -f "$DATADIR/test-rules.file" | (
+  file_rules=0
+  while read -r type rule; do
+    if [ "$type" = OUTPUT: ] && [ -n "$rule" ]; then
+      echo "FOUND: $rule"
+      file_rules=$((file_rules + 1))
+    fi
+  done
+
+  if [ "$file_rules" -eq 0 ]; then
+    echo "======================"
+    echo "FAILED: no rules found"
+    echo "^^^^^^^^^^^^^^^^^^^^^^"
+    exit 1
+  fi
+) || RETVAL=1
+
 exit $RETVAL


### PR DESCRIPTION
I initially reported this a while ago (https://github.com/USBGuard/usbguard/issues/111#issuecomment-350824028) and decided to give it a try after seeing the resolution of #111.