### PR TITLE
Namespace generically named LDAP attributes

### DIFF
--- a/scripts/ldap/schema2ldif.pl
+++ b/scripts/ldap/schema2ldif.pl
@@ -1,0 +1,50 @@
+#!/usr/bin/env perl
+# Converts OpenLDAP schema from traditional slapd.conf format to LDIF format
+# usable for importing into cn=config.
+#
+# Copyright (c) 2012-2016 Mantas Mikulėnas <grawity@gmail.com>
+# Released under the MIT license <https://spdx.org/licenses/MIT>
+
+use warnings;
+use strict;
+
+my $name = shift(@ARGV) // "UNNAMED-SCHEMA";
+my $unwrap = 0;
+
+print "dn: cn=$name,cn=schema,cn=config\n";
+print "objectClass: olcSchemaConfig\n";
+
+my $key;
+my $value;
+
+while (<STDIN>) {
+	if (/^(attributeType(?:s)?|objectClass(?:es)?) (.+)$/i) {
+		if ($key && $value) {
+			print "$key: $value\n";
+		}
+		($key, $value) = ($1, $2);
+		if ($key =~ /^attributeType(s)?$/i) {
+			$key = "olcAttributeTypes";
+		} elsif ($key =~ /^objectClass(es)?$/i) {
+			$key = "olcObjectClasses";
+		} else {
+			$key = "olc$key";
+		}
+	}
+	elsif (/^\s+(.+)$/) {
+		if ($unwrap) {
+			$value .= " $1";
+		} else {
+			$value .= "\n $&";
+		}
+	}
+	elsif (/^#.*/) {
+		print "$&\n";
+	}
+	elsif (/.+/) {
+		warn "$.:unrecognized input line: $&\n";
+	}
+}
+if ($key && $value) {
+	print "$key: $value\n";
+}

--- a/scripts/ldap/usbguard.ldif
+++ b/scripts/ldap/usbguard.ldif
@@ -1,41 +1,74 @@
 dn: cn=usbguard,cn=schema,cn=config
 objectClass: olcSchemaConfig
 cn: usbguard
-olcAttributeTypes: {0}( 1.3.6.1.4.1.15955.9.1.1 NAME 'RuleType' DESC 'Hostna
- me for USBGuard host' EQUALITY caseExactIA5Match SUBSTR caseExactIA5Substri
- ngsMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.26 )
-olcAttributeTypes: {1}( 1.3.6.1.4.1.15955.9.1.2 NAME 'USBGuardHost' DESC 'Ho
- stname for USBGuard host' EQUALITY caseExactIA5Match SUBSTR caseExactIA5Sub
- stringsMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.26 )
-olcAttributeTypes: {2}( 1.3.6.1.4.1.15955.9.1.3 NAME 'USBGuardOrder' DESC 'a
- n integer to order the USBGuard Policy entries' EQUALITY integerMatch ORDER
- ING integerOrderingMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.27 )
-olcAttributeTypes: {3}( 1.3.6.1.4.1.15955.9.1.4 NAME 'DeviceID' DESC 'USB de
- vice ID' EQUALITY caseExactIA5Match SUBSTR caseExactIA5SubstringsMatch SYNT
- AX 1.3.6.1.4.1.1466.115.121.1.26 )
-olcAttributeTypes: {4}( 1.3.6.1.4.1.15955.9.1.5 NAME 'DeviceSerial' DESC 'US
- B device Serial' EQUALITY caseExactIA5Match SUBSTR caseExactIA5SubstringsMa
- tch SYNTAX 1.3.6.1.4.1.1466.115.121.1.26 )
-olcAttributeTypes: {5}( 1.3.6.1.4.1.15955.9.1.6 NAME 'DeviceName' DESC 'USB 
- device Name' EQUALITY caseExactIA5Match SUBSTR caseExactIA5SubstringsMatch 
- SYNTAX 1.3.6.1.4.1.1466.115.121.1.26 )
-olcAttributeTypes: {6}( 1.3.6.1.4.1.15955.9.1.7 NAME 'DeviceHash' DESC 'USB 
- device hash' EQUALITY caseExactIA5Match SUBSTR caseExactIA5SubstringsMatch 
- SYNTAX 1.3.6.1.4.1.1466.115.121.1.26 )
-olcAttributeTypes: {7}( 1.3.6.1.4.1.15955.9.1.8 NAME 'DeviceParentHash' DESC
-  'USB device ParentHash' EQUALITY caseExactIA5Match SUBSTR caseExactIA5Subs
- tringsMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.26 )
-olcAttributeTypes: {8}( 1.3.6.1.4.1.15955.9.1.9 NAME 'DeviceViaPort' DESC 'U
- SB device ViaPort' EQUALITY caseExactIA5Match SUBSTR caseExactIA5Substrings
- Match SYNTAX 1.3.6.1.4.1.1466.115.121.1.26 )
-olcAttributeTypes: {9}( 1.3.6.1.4.1.15955.9.1.10 NAME 'DeviceWithInterface' 
- DESC 'USB device With-Interface' EQUALITY caseExactIA5Match SUBSTR caseExac
- tIA5SubstringsMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.26 )
-olcAttributeTypes: {10}( 1.3.6.1.4.1.15955.9.1.11 NAME 'RuleCondition' DESC 
- 'Condition' EQUALITY caseExactIA5Match SUBSTR caseExactIA5SubstringsMatch S
- YNTAX 1.3.6.1.4.1.1466.115.121.1.26 )
-olcObjectClasses: {0}( 1.3.6.1.4.1.15955.9.1.1 NAME 'USBGuardPolicy' DESC 'U
- SBGuard Policy' SUP top STRUCTURAL MUST ( cn $ RuleType $ USBGuardHost $ US
- BGuardOrder ) MAY ( DeviceID $ DeviceSerial $ DeviceName $ DeviceHash $ Dev
- iceParentHash $ DeviceViaPort $ DeviceWithInterface $ RuleCondition $ descr
- iption ) )
+olcAttributeTypes: ( 1.3.6.1.4.1.15955.9.1.1
+   NAME 'USBGuardRuleTarget'
+   DESC 'Hostname for USBGuard host'
+   EQUALITY caseExactIA5Match
+   SUBSTR caseExactIA5SubstringsMatch
+   SYNTAX 1.3.6.1.4.1.1466.115.121.1.26 )
+olcAttributeTypes: ( 1.3.6.1.4.1.15955.9.1.2
+   NAME 'USBGuardHost'
+   DESC 'Hostname for USBGuard host'
+   EQUALITY caseExactIA5Match
+   SUBSTR caseExactIA5SubstringsMatch
+   SYNTAX 1.3.6.1.4.1.1466.115.121.1.26 )
+olcAttributeTypes: ( 1.3.6.1.4.1.15955.9.1.3
+   NAME 'USBGuardRuleOrder'
+   DESC 'an integer to order the USBGuard Policy entries'
+   EQUALITY integerMatch
+   ORDERING integerOrderingMatch
+   SYNTAX 1.3.6.1.4.1.1466.115.121.1.27 )
+olcAttributeTypes: ( 1.3.6.1.4.1.15955.9.1.4
+   NAME 'USBID'
+   DESC 'USB device ID'
+   EQUALITY caseExactIA5Match
+   SUBSTR caseExactIA5SubstringsMatch
+   SYNTAX 1.3.6.1.4.1.1466.115.121.1.26 )
+olcAttributeTypes: ( 1.3.6.1.4.1.15955.9.1.5
+   NAME 'USBSerial'
+   DESC 'USB device Serial'
+   EQUALITY caseExactIA5Match
+   SUBSTR caseExactIA5SubstringsMatch
+   SYNTAX 1.3.6.1.4.1.1466.115.121.1.26 )
+olcAttributeTypes: ( 1.3.6.1.4.1.15955.9.1.6
+   NAME 'USBName'
+   DESC 'USB device Name'
+   EQUALITY caseExactIA5Match
+   SUBSTR caseExactIA5SubstringsMatch
+   SYNTAX 1.3.6.1.4.1.1466.115.121.1.26 )
+olcAttributeTypes: ( 1.3.6.1.4.1.15955.9.1.7
+   NAME 'USBHash'
+   DESC 'USB device hash'
+   EQUALITY caseExactIA5Match
+   SUBSTR caseExactIA5SubstringsMatch
+   SYNTAX 1.3.6.1.4.1.1466.115.121.1.26 )
+olcAttributeTypes: ( 1.3.6.1.4.1.15955.9.1.8
+   NAME 'USBParentHash'
+   DESC 'USB device ParentHash'
+   EQUALITY caseExactIA5Match
+   SUBSTR caseExactIA5SubstringsMatch
+   SYNTAX 1.3.6.1.4.1.1466.115.121.1.26 )
+olcAttributeTypes: ( 1.3.6.1.4.1.15955.9.1.9
+   NAME 'USBViaPort'
+   DESC 'USB device ViaPort'
+   EQUALITY caseExactIA5Match
+   SUBSTR caseExactIA5SubstringsMatch
+   SYNTAX 1.3.6.1.4.1.1466.115.121.1.26 )
+olcAttributeTypes: ( 1.3.6.1.4.1.15955.9.1.10
+   NAME 'USBWithInterface'
+   DESC 'USB device With-Interface'
+   EQUALITY caseExactIA5Match
+   SUBSTR caseExactIA5SubstringsMatch
+   SYNTAX 1.3.6.1.4.1.1466.115.121.1.26 )
+olcAttributeTypes: ( 1.3.6.1.4.1.15955.9.1.11
+   NAME 'USBGuardRuleCondition'
+   DESC 'Condition'
+   EQUALITY caseExactIA5Match
+   SUBSTR caseExactIA5SubstringsMatch
+   SYNTAX 1.3.6.1.4.1.1466.115.121.1.26 )
+olcObjectClasses: ( 1.3.6.1.4.1.15955.9.1.1 NAME 'USBGuardPolicy' SUP top STRUCTURAL
+   DESC 'USBGuard Policy'
+   MUST ( cn $ USBGuardRuleTarget $ USBGuardHost $ USBGuardRuleOrder )
+   MAY  ( USBID $ USBSerial $ USBName $ USBHash $ USBParentHash $ USBViaPort $ USBWithInterface $ USBGuardRuleCondition $ description )
+   )

--- a/scripts/ldap/usbguard.schema
+++ b/scripts/ldap/usbguard.schema
@@ -1,5 +1,5 @@
 attributetype ( 1.3.6.1.4.1.15955.9.1.1
-  NAME 'RuleType'
+  NAME 'USBGuardRuleTarget'
   DESC 'Hostname for USBGuard host'
   EQUALITY caseExactIA5Match
   SUBSTR caseExactIA5SubstringsMatch
@@ -12,64 +12,64 @@ attributetype ( 1.3.6.1.4.1.15955.9.1.2
   SUBSTR caseExactIA5SubstringsMatch
   SYNTAX 1.3.6.1.4.1.1466.115.121.1.26 )
 
-attributeTypes ( 1.3.6.1.4.1.15955.9.1.3
-  NAME 'USBGuardOrder'
+attributetype ( 1.3.6.1.4.1.15955.9.1.3
+  NAME 'USBGuardRuleOrder'
   DESC 'an integer to order the USBGuard Policy entries'
   EQUALITY integerMatch
   ORDERING integerOrderingMatch
   SYNTAX 1.3.6.1.4.1.1466.115.121.1.27 )
 
 attributetype ( 1.3.6.1.4.1.15955.9.1.4
-  NAME 'DeviceID'
+  NAME 'USBID'
   DESC 'USB device ID'
   EQUALITY caseExactIA5Match
   SUBSTR caseExactIA5SubstringsMatch
   SYNTAX 1.3.6.1.4.1.1466.115.121.1.26 )
 
 attributetype ( 1.3.6.1.4.1.15955.9.1.5
-  NAME 'DeviceSerial'
+  NAME 'USBSerial'
   DESC 'USB device Serial'
   EQUALITY caseExactIA5Match
   SUBSTR caseExactIA5SubstringsMatch
   SYNTAX 1.3.6.1.4.1.1466.115.121.1.26 )
 
 attributetype ( 1.3.6.1.4.1.15955.9.1.6
-  NAME 'DeviceName'
+  NAME 'USBName'
   DESC 'USB device Name'
   EQUALITY caseExactIA5Match
   SUBSTR caseExactIA5SubstringsMatch
   SYNTAX 1.3.6.1.4.1.1466.115.121.1.26 )
 
 attributetype ( 1.3.6.1.4.1.15955.9.1.7
-  NAME 'DeviceHash'
+  NAME 'USBHash'
   DESC 'USB device hash'
   EQUALITY caseExactIA5Match
   SUBSTR caseExactIA5SubstringsMatch
   SYNTAX 1.3.6.1.4.1.1466.115.121.1.26 )
 
 attributetype ( 1.3.6.1.4.1.15955.9.1.8
-  NAME 'DeviceParentHash'
+  NAME 'USBParentHash'
   DESC 'USB device ParentHash'
   EQUALITY caseExactIA5Match
   SUBSTR caseExactIA5SubstringsMatch
   SYNTAX 1.3.6.1.4.1.1466.115.121.1.26 )
 
 attributetype ( 1.3.6.1.4.1.15955.9.1.9
-  NAME 'DeviceViaPort'
+  NAME 'USBViaPort'
   DESC 'USB device ViaPort'
   EQUALITY caseExactIA5Match
   SUBSTR caseExactIA5SubstringsMatch
   SYNTAX 1.3.6.1.4.1.1466.115.121.1.26 )
 
 attributetype ( 1.3.6.1.4.1.15955.9.1.10
-  NAME 'DeviceWithInterface'
+  NAME 'USBWithInterface'
   DESC 'USB device With-Interface'
   EQUALITY caseExactIA5Match
   SUBSTR caseExactIA5SubstringsMatch
   SYNTAX 1.3.6.1.4.1.1466.115.121.1.26 )
 
 attributetype ( 1.3.6.1.4.1.15955.9.1.11
-  NAME 'RuleCondition'
+  NAME 'USBGuardRuleCondition'
   DESC 'Condition'
   EQUALITY caseExactIA5Match
   SUBSTR caseExactIA5SubstringsMatch
@@ -77,6 +77,6 @@ attributetype ( 1.3.6.1.4.1.15955.9.1.11
 
 objectclass ( 1.3.6.1.4.1.15955.9.1.1 NAME 'USBGuardPolicy' SUP top STRUCTURAL
   DESC 'USBGuard Policy'
-  MUST ( cn $ RuleType $ USBGuardHost $ USBGuardOrder )
-  MAY  ( DeviceID $ DeviceSerial $ DeviceName $ DeviceHash $ DeviceParentHash $ DeviceViaPort $ DeviceWithInterface $ RuleCondition $ description )
+  MUST ( cn $ USBGuardRuleTarget $ USBGuardHost $ USBGuardRuleOrder )
+  MAY  ( USBID $ USBSerial $ USBName $ USBHash $ USBParentHash $ USBViaPort $ USBWithInterface $ USBGuardRuleCondition $ description )
   )

--- a/src/Common/LDAPUtil.cpp
+++ b/src/Common/LDAPUtil.cpp
@@ -28,9 +28,9 @@
 namespace usbguard
 {
   std::vector<std::string> LDAPUtil::_ldap_keys = {
-    "RuleTarget",
+    "USBGuardRuleTarget",
     "USBGuardHost",
-    "RuleOrder",
+    "USBGuardRuleOrder",
     "USBID",
     "USBSerial",
     "USBName",
@@ -38,7 +38,7 @@ namespace usbguard
     "USBParentHash",
     "USBViaPort",
     "USBWithInterface",
-    "RuleCondition"
+    "USBGuardRuleCondition"
   };
 
   std::vector<std::string> LDAPUtil::_rule_keys = {
@@ -96,7 +96,7 @@ namespace usbguard
     rule_string += "objectClass: " + values["OBJCLASS"] + "\n";
     rule_string += "objectClass: top\n";
     rule_string += "cn: " + name + "\n";
-    rule_string += LDAPUtil::_ldap_keys[static_cast<unsigned>(LDAPUtil::LDAP_KEY_INDEX::RuleTarget)] + ": ";
+    rule_string += LDAPUtil::_ldap_keys[static_cast<unsigned>(LDAPUtil::LDAP_KEY_INDEX::USBGuardRuleTarget)] + ": ";
 
     try {
       rule_string.append(Rule::targetToString(rule->getTarget()));

--- a/src/Common/LDAPUtil.hpp
+++ b/src/Common/LDAPUtil.hpp
@@ -33,9 +33,9 @@ namespace usbguard
   {
   public:
     enum class LDAP_KEY_INDEX {
-      RuleTarget = 0,
+      USBGuardRuleTarget = 0,
       USBGuardHost,
-      RuleOrder,
+      USBGuardRuleOrder,
       USBID,
       USBSerial,
       USBName,
@@ -43,7 +43,7 @@ namespace usbguard
       USBParentHash,
       USBViaPort,
       USBWithInterface,
-      RuleCondition
+      USBGuardRuleCondition
     };
     static std::vector<std::string> _ldap_keys;
     static std::vector<std::string> _rule_keys;

--- a/src/Daemon/LDAPHandler.cpp
+++ b/src/Daemon/LDAPHandler.cpp
@@ -167,7 +167,7 @@ namespace usbguard
           size_t index = 0;
 
           switch (static_cast<LDAPUtil::LDAP_KEY_INDEX>(i)) {
-          case LDAPUtil::LDAP_KEY_INDEX::RuleTarget:
+          case LDAPUtil::LDAP_KEY_INDEX::USBGuardRuleTarget:
             rule.second += value;
             break;
 
@@ -178,15 +178,15 @@ namespace usbguard
           case LDAPUtil::LDAP_KEY_INDEX::USBParentHash:
           case LDAPUtil::LDAP_KEY_INDEX::USBViaPort:
           case LDAPUtil::LDAP_KEY_INDEX::USBWithInterface:
-          case LDAPUtil::LDAP_KEY_INDEX::RuleCondition:
+          case LDAPUtil::LDAP_KEY_INDEX::USBGuardRuleCondition:
             rule.second += " " + LDAPUtil::_rule_keys[i] + " " + value;
             break;
 
-          case LDAPUtil::LDAP_KEY_INDEX::RuleOrder:
+          case LDAPUtil::LDAP_KEY_INDEX::USBGuardRuleOrder:
             rule.first = std::stol(value, &index);
 
             if (value[index] != 0) {
-              throw Exception("ldapToRules", "stol", "cannot convert RuleOrder to number: " + value);
+              throw Exception("ldapToRules", "stol", "cannot convert USBGuardRuleOrder to number: " + value);
             }
 
             break;

--- a/src/Tests/LDAP/Sanity/ldap-nsswitch.sh
+++ b/src/Tests/LDAP/Sanity/ldap-nsswitch.sh
@@ -56,9 +56,9 @@ dn: cn=Rule1,ou=USBGuard,dc=example,dc=com
 objectClass: USBGuardPolicy
 objectClass: top
 cn: Rule1
-RuleTarget: allow
+USBGuardRuleTarget: allow
 USBGuardHost: *
-RuleOrder: 1
+USBGuardRuleOrder: 1
 EOF
 
 ${LDAP_UTIL} delete && true

--- a/src/Tests/LDAP/UseCase/ldap-test-1.sh
+++ b/src/Tests/LDAP/UseCase/ldap-test-1.sh
@@ -60,9 +60,9 @@ dn: cn=Rule1,ou=USBGuard,dc=example,dc=com
 objectClass: USBGuardPolicy
 objectClass: top
 cn: Rule1
-RuleTarget: allow
+USBGuardRuleTarget: allow
 USBGuardHost: *
-RuleOrder: 1
+USBGuardRuleOrder: 1
 EOF
 
 sudo -n cat > "$config_path" <<EOF

--- a/src/Tests/LDAP/UseCase/ldap-test-5.sh
+++ b/src/Tests/LDAP/UseCase/ldap-test-5.sh
@@ -60,9 +60,9 @@ dn: cn=Rule1,ou=USBGuard,dc=example,dc=com
 objectClass: USBGuardPolicy
 objectClass: top
 cn: Rule1
-RuleTarget: allow
+USBGuardRuleTarget: allow
 USBGuardHost: *
-RuleOrder: 0
+USBGuardRuleOrder: 0
 USBID: 1038:1702
 USBSerial: ""
 USBName: "SteelSeries Rival 100 Gaming Mouse"
@@ -75,10 +75,10 @@ dn: cn=Rule2,ou=USBGuard,dc=example,dc=com
 objectClass: USBGuardPolicy
 objectClass: top
 cn: Rule2
-RuleTarget: allow
+USBGuardRuleTarget: allow
 USBGuardHost: *
 USBGuardHost: !RandomHOSt
-RuleOrder: 1
+USBGuardRuleOrder: 1
 USBID: 1038:1702
 USBSerial: ""
 USBName: "Keyboard..."
@@ -90,9 +90,9 @@ dn: cn=Rule3,ou=USBGuard,dc=example,dc=com
 objectClass: USBGuardPolicy
 objectClass: top
 cn: Rule3
-RuleTarget: allow
+USBGuardRuleTarget: allow
 USBGuardHost: *
-RuleOrder: 6
+USBGuardRuleOrder: 6
 USBID: 1038:1702
 USBSerial: ""
 USBName: "Flash"
@@ -103,9 +103,9 @@ dn: cn=Rule4,ou=USBGuard,dc=example,dc=com
 objectClass: USBGuardPolicy
 objectClass: top
 cn: Rule4
-RuleTarget: allow
+USBGuardRuleTarget: allow
 USBGuardHost: *
-RuleOrder: 2
+USBGuardRuleOrder: 2
 EOF
 
 

--- a/src/Tests/LDAP/usbguard-policy.ldif
+++ b/src/Tests/LDAP/usbguard-policy.ldif
@@ -2,9 +2,9 @@ dn: cn=Rule1,ou=USBGuard,dc=example,dc=com
 objectClass: USBGuardPolicy
 objectClass: top
 cn: Rule1
-RuleTarget: allow
+USBRuleTarget: allow
 USBGuardHost: *
-RuleOrder: 0
+USBRuleOrder: 0
 USBID: 1038:1702
 USBSerial: ""
 USBName: "SteelSeries Rival 100 Gaming Mouse"
@@ -17,10 +17,10 @@ dn: cn=Rule2,ou=USBGuard,dc=example,dc=com
 objectClass: USBGuardPolicy
 objectClass: top
 cn: Rule2
-RuleTarget: allow
+USBRuleTarget: allow
 USBGuardHost: *
 USBGuardHost: !RandomHOSt
-RuleOrder: 1
+USBRuleOrder: 1
 USBID: 1038:1702
 USBSerial: ""
 USBName: "Keyboard..."
@@ -32,9 +32,9 @@ dn: cn=Rule3,ou=USBGuard,dc=example,dc=com
 objectClass: USBGuardPolicy
 objectClass: top
 cn: Rule3
-RuleTarget: allow
+USBRuleTarget: allow
 USBGuardHost: *
-RuleOrder: 6
+USBRuleOrder: 6
 USBID: 1038:1702
 USBSerial: ""
 USBName: "Flash"
@@ -45,6 +45,6 @@ dn: cn=Rule4,ou=USBGuard,dc=example,dc=com
 objectClass: USBGuardPolicy
 objectClass: top
 cn: Rule4
-RuleTarget: allow
+USBRuleTarget: allow
 USBGuardHost: *
-RuleOrder: 2
+USBRuleOrder: 2

--- a/src/Tests/LDAP/usbguard.ldif
+++ b/src/Tests/LDAP/usbguard.ldif
@@ -1,40 +1,74 @@
 dn: cn=usbguard,cn=schema,cn=config
 objectClass: olcSchemaConfig
 cn: usbguard
-olcAttributeTypes: {0}( 1.3.6.1.4.1.15955.9.1.1 NAME 'USBGuardRuleTarget' DESC 'Hostna
- me for USBGuard host' EQUALITY caseExactIA5Match SUBSTR caseExactIA5Substri
- ngsMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.26 )
-olcAttributeTypes: {1}( 1.3.6.1.4.1.15955.9.1.2 NAME 'USBGuardHost' DESC 'Ho
- stname for USBGuard host' EQUALITY caseExactIA5Match SUBSTR caseExactIA5Sub
- stringsMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.26 )
-olcAttributeTypes: {2}( 1.3.6.1.4.1.15955.9.1.3 NAME 'USBGuardRuleOrder' DESC 'a
- n integer to order the USBGuard Policy entries' EQUALITY integerMatch ORDER
- ING integerOrderingMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.27 )
-olcAttributeTypes: {3}( 1.3.6.1.4.1.15955.9.1.4 NAME 'USBID' DESC 'USB de
- vice ID' EQUALITY caseExactIA5Match SUBSTR caseExactIA5SubstringsMatch SYNT
- AX 1.3.6.1.4.1.1466.115.121.1.26 )
-olcAttributeTypes: {4}( 1.3.6.1.4.1.15955.9.1.5 NAME 'USBSerial' DESC 'US
- B device Serial' EQUALITY caseExactIA5Match SUBSTR caseExactIA5SubstringsMa
- tch SYNTAX 1.3.6.1.4.1.1466.115.121.1.26 )
-olcAttributeTypes: {5}( 1.3.6.1.4.1.15955.9.1.6 NAME 'USBName' DESC 'USB 
- device Name' EQUALITY caseExactIA5Match SUBSTR caseExactIA5SubstringsMatch 
- SYNTAX 1.3.6.1.4.1.1466.115.121.1.26 )
-olcAttributeTypes: {6}( 1.3.6.1.4.1.15955.9.1.7 NAME 'USBHash' DESC 'USB 
- device hash' EQUALITY caseExactIA5Match SUBSTR caseExactIA5SubstringsMatch 
- SYNTAX 1.3.6.1.4.1.1466.115.121.1.26 )
-olcAttributeTypes: {7}( 1.3.6.1.4.1.15955.9.1.8 NAME 'USBParentHash' DESC
-  'USB device ParentHash' EQUALITY caseExactIA5Match SUBSTR caseExactIA5Subs
- tringsMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.26 )
-olcAttributeTypes: {8}( 1.3.6.1.4.1.15955.9.1.9 NAME 'USBViaPort' DESC 'U
- SB device ViaPort' EQUALITY caseExactIA5Match SUBSTR caseExactIA5Substrings
- Match SYNTAX 1.3.6.1.4.1.1466.115.121.1.26 )
-olcAttributeTypes: {9}( 1.3.6.1.4.1.15955.9.1.10 NAME 'USBWithInterface' 
- DESC 'USB device With-Interface' EQUALITY caseExactIA5Match SUBSTR caseExac
- tIA5SubstringsMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.26 )
-olcAttributeTypes: {10}( 1.3.6.1.4.1.15955.9.1.11 NAME 'USBGuardRuleCondition' DESC 
- 'Condition' EQUALITY caseExactIA5Match SUBSTR caseExactIA5SubstringsMatch S
- YNTAX 1.3.6.1.4.1.1466.115.121.1.26 )
-olcObjectClasses: {0}( 1.3.6.1.4.1.15955.9.1.1 NAME 'USBGuardPolicy' DESC 'U
- SBGuard Policy' SUP top STRUCTURAL MUST ( cn $ USBGuardRuleTarget $ USBGuardHost $ 
- USBGuardRuleOrder ) MAY ( USBID $ USBSerial $ USBName $ USBHash $ USBParentHash $ 
- USBViaPort $ USBWithInterface $ USBGuardRuleCondition $ description ) )
+olcAttributeTypes: ( 1.3.6.1.4.1.15955.9.1.1
+   NAME 'USBGuardRuleTarget'
+   DESC 'Hostname for USBGuard host'
+   EQUALITY caseExactIA5Match
+   SUBSTR caseExactIA5SubstringsMatch
+   SYNTAX 1.3.6.1.4.1.1466.115.121.1.26 )
+olcAttributeTypes: ( 1.3.6.1.4.1.15955.9.1.2
+   NAME 'USBGuardHost'
+   DESC 'Hostname for USBGuard host'
+   EQUALITY caseExactIA5Match
+   SUBSTR caseExactIA5SubstringsMatch
+   SYNTAX 1.3.6.1.4.1.1466.115.121.1.26 )
+olcAttributeTypes: ( 1.3.6.1.4.1.15955.9.1.3
+   NAME 'USBGuardRuleOrder'
+   DESC 'an integer to order the USBGuard Policy entries'
+   EQUALITY integerMatch
+   ORDERING integerOrderingMatch
+   SYNTAX 1.3.6.1.4.1.1466.115.121.1.27 )
+olcAttributeTypes: ( 1.3.6.1.4.1.15955.9.1.4
+   NAME 'USBID'
+   DESC 'USB device ID'
+   EQUALITY caseExactIA5Match
+   SUBSTR caseExactIA5SubstringsMatch
+   SYNTAX 1.3.6.1.4.1.1466.115.121.1.26 )
+olcAttributeTypes: ( 1.3.6.1.4.1.15955.9.1.5
+   NAME 'USBSerial'
+   DESC 'USB device Serial'
+   EQUALITY caseExactIA5Match
+   SUBSTR caseExactIA5SubstringsMatch
+   SYNTAX 1.3.6.1.4.1.1466.115.121.1.26 )
+olcAttributeTypes: ( 1.3.6.1.4.1.15955.9.1.6
+   NAME 'USBName'
+   DESC 'USB device Name'
+   EQUALITY caseExactIA5Match
+   SUBSTR caseExactIA5SubstringsMatch
+   SYNTAX 1.3.6.1.4.1.1466.115.121.1.26 )
+olcAttributeTypes: ( 1.3.6.1.4.1.15955.9.1.7
+   NAME 'USBHash'
+   DESC 'USB device hash'
+   EQUALITY caseExactIA5Match
+   SUBSTR caseExactIA5SubstringsMatch
+   SYNTAX 1.3.6.1.4.1.1466.115.121.1.26 )
+olcAttributeTypes: ( 1.3.6.1.4.1.15955.9.1.8
+   NAME 'USBParentHash'
+   DESC 'USB device ParentHash'
+   EQUALITY caseExactIA5Match
+   SUBSTR caseExactIA5SubstringsMatch
+   SYNTAX 1.3.6.1.4.1.1466.115.121.1.26 )
+olcAttributeTypes: ( 1.3.6.1.4.1.15955.9.1.9
+   NAME 'USBViaPort'
+   DESC 'USB device ViaPort'
+   EQUALITY caseExactIA5Match
+   SUBSTR caseExactIA5SubstringsMatch
+   SYNTAX 1.3.6.1.4.1.1466.115.121.1.26 )
+olcAttributeTypes: ( 1.3.6.1.4.1.15955.9.1.10
+   NAME 'USBWithInterface'
+   DESC 'USB device With-Interface'
+   EQUALITY caseExactIA5Match
+   SUBSTR caseExactIA5SubstringsMatch
+   SYNTAX 1.3.6.1.4.1.1466.115.121.1.26 )
+olcAttributeTypes: ( 1.3.6.1.4.1.15955.9.1.11
+   NAME 'USBGuardRuleCondition'
+   DESC 'Condition'
+   EQUALITY caseExactIA5Match
+   SUBSTR caseExactIA5SubstringsMatch
+   SYNTAX 1.3.6.1.4.1.1466.115.121.1.26 )
+olcObjectClasses: ( 1.3.6.1.4.1.15955.9.1.1 NAME 'USBGuardPolicy' SUP top STRUCTURAL
+   DESC 'USBGuard Policy'
+   MUST ( cn $ USBGuardRuleTarget $ USBGuardHost $ USBGuardRuleOrder )
+   MAY  ( USBID $ USBSerial $ USBName $ USBHash $ USBParentHash $ USBViaPort $ USBWithInterface $ USBGuardRuleCondition $ description )
+   )

--- a/src/Tests/LDAP/usbguard.ldif
+++ b/src/Tests/LDAP/usbguard.ldif
@@ -1,13 +1,13 @@
 dn: cn=usbguard,cn=schema,cn=config
 objectClass: olcSchemaConfig
 cn: usbguard
-olcAttributeTypes: {0}( 1.3.6.1.4.1.15955.9.1.1 NAME 'RuleTarget' DESC 'Hostna
+olcAttributeTypes: {0}( 1.3.6.1.4.1.15955.9.1.1 NAME 'USBGuardRuleTarget' DESC 'Hostna
  me for USBGuard host' EQUALITY caseExactIA5Match SUBSTR caseExactIA5Substri
  ngsMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.26 )
 olcAttributeTypes: {1}( 1.3.6.1.4.1.15955.9.1.2 NAME 'USBGuardHost' DESC 'Ho
  stname for USBGuard host' EQUALITY caseExactIA5Match SUBSTR caseExactIA5Sub
  stringsMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.26 )
-olcAttributeTypes: {2}( 1.3.6.1.4.1.15955.9.1.3 NAME 'RuleOrder' DESC 'a
+olcAttributeTypes: {2}( 1.3.6.1.4.1.15955.9.1.3 NAME 'USBGuardRuleOrder' DESC 'a
  n integer to order the USBGuard Policy entries' EQUALITY integerMatch ORDER
  ING integerOrderingMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.27 )
 olcAttributeTypes: {3}( 1.3.6.1.4.1.15955.9.1.4 NAME 'USBID' DESC 'USB de
@@ -31,10 +31,10 @@ olcAttributeTypes: {8}( 1.3.6.1.4.1.15955.9.1.9 NAME 'USBViaPort' DESC 'U
 olcAttributeTypes: {9}( 1.3.6.1.4.1.15955.9.1.10 NAME 'USBWithInterface' 
  DESC 'USB device With-Interface' EQUALITY caseExactIA5Match SUBSTR caseExac
  tIA5SubstringsMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.26 )
-olcAttributeTypes: {10}( 1.3.6.1.4.1.15955.9.1.11 NAME 'RuleCondition' DESC 
+olcAttributeTypes: {10}( 1.3.6.1.4.1.15955.9.1.11 NAME 'USBGuardRuleCondition' DESC 
  'Condition' EQUALITY caseExactIA5Match SUBSTR caseExactIA5SubstringsMatch S
  YNTAX 1.3.6.1.4.1.1466.115.121.1.26 )
 olcObjectClasses: {0}( 1.3.6.1.4.1.15955.9.1.1 NAME 'USBGuardPolicy' DESC 'U
- SBGuard Policy' SUP top STRUCTURAL MUST ( cn $ RuleTarget $ USBGuardHost $
- RuleOrder ) MAY ( USBID $ USBSerial $ USBName $ USBHash $ USBParentHash $
- USBViaPort $ USBWithInterface $ RuleCondition $ description ) )
+ SBGuard Policy' SUP top STRUCTURAL MUST ( cn $ USBGuardRuleTarget $ USBGuardHost $ 
+ USBGuardRuleOrder ) MAY ( USBID $ USBSerial $ USBName $ USBHash $ USBParentHash $ 
+ USBViaPort $ USBWithInterface $ USBGuardRuleCondition $ description ) )

--- a/src/Tests/LDAP/usbguard.schema
+++ b/src/Tests/LDAP/usbguard.schema
@@ -1,5 +1,5 @@
 attributetype ( 1.3.6.1.4.1.15955.9.1.1
-  NAME 'RuleTarget'
+  NAME 'USBGuardRuleTarget'
   DESC 'Hostname for USBGuard host'
   EQUALITY caseExactIA5Match
   SUBSTR caseExactIA5SubstringsMatch
@@ -12,8 +12,8 @@ attributetype ( 1.3.6.1.4.1.15955.9.1.2
   SUBSTR caseExactIA5SubstringsMatch
   SYNTAX 1.3.6.1.4.1.1466.115.121.1.26 )
 
-attributeTypes ( 1.3.6.1.4.1.15955.9.1.3
-  NAME 'RuleOrder'
+attributetype ( 1.3.6.1.4.1.15955.9.1.3
+  NAME 'USBGuardRuleOrder'
   DESC 'an integer to order the USBGuard Policy entries'
   EQUALITY integerMatch
   ORDERING integerOrderingMatch
@@ -69,7 +69,7 @@ attributetype ( 1.3.6.1.4.1.15955.9.1.10
   SYNTAX 1.3.6.1.4.1.1466.115.121.1.26 )
 
 attributetype ( 1.3.6.1.4.1.15955.9.1.11
-  NAME 'RuleCondition'
+  NAME 'USBGuardRuleCondition'
   DESC 'Condition'
   EQUALITY caseExactIA5Match
   SUBSTR caseExactIA5SubstringsMatch
@@ -77,6 +77,6 @@ attributetype ( 1.3.6.1.4.1.15955.9.1.11
 
 objectclass ( 1.3.6.1.4.1.15955.9.1.1 NAME 'USBGuardPolicy' SUP top STRUCTURAL
   DESC 'USBGuard Policy'
-  MUST ( cn $ RuleTarget $ USBGuardHost $ RuleOrder )
-  MAY  ( USBID $ USBSerial $ USBName $ USBHash $ USBParentHash $ USBViaPort $ USBWithInterface $ RuleCondition $ description )
+  MUST ( cn $ USBGuardRuleTarget $ USBGuardHost $ USBGuardRuleOrder )
+  MAY  ( USBID $ USBSerial $ USBName $ USBHash $ USBParentHash $ USBViaPort $ USBWithInterface $ USBGuardRuleCondition $ description )
   )


### PR DESCRIPTION
I noticed that recently LDAP support was added to USBGuard, which adds some attributes including the generically named `RuleTarget` and `RuleOrder`.

Since attribute names have to be unique across the LDAP server, even between schemas (and no, the OIDs are mostly just for show), this has somewhat greater chance of colliding with someone's existing schema in the future.

So while the code is still warm, I would recommend prefixing those two attributes with `USBGuard…` or at least `USB…`, like the remaining ones. With namespacing, name collisions are much less likely.