### PR TITLE
Add a daemon config option HidePii.

### DIFF
--- a/src/Daemon/Daemon.cpp
+++ b/src/Daemon/Daemon.cpp
@@ -67,7 +67,8 @@ namespace usbguard
     "DeviceManagerBackend",
     "IPCAccessControlFiles",
     "AuditFilePath",
-    "AuditBackend"
+    "AuditBackend",
+    "HidePII"
   };
 
   static const std::vector<std::pair<std::string, Daemon::DevicePolicyMethod>> device_policy_method_strings = {
@@ -332,6 +333,18 @@ namespace usbguard
       else {
         USBGUARD_LOG(Info) << "Audit logging disabled. Set AuditBackend and/or AuditFilePath to enable.";
         _audit.setBackend(nullptr);
+      }
+    }
+
+    /* HidePII */
+    if (_config.hasSettingValue("HidePII")) {
+      const std::string value = _config.getSettingValue("HidePII");
+
+      if (value == "true") {
+        _audit.setHidePII(true);
+      }
+      else if (value != "false") {
+        throw Exception("Configuration", "HidePII", "Invalid value");
       }
     }
 

--- a/src/Library/RulePrivate.cpp
+++ b/src/Library/RulePrivate.cpp
@@ -420,7 +420,7 @@ namespace usbguard
     return;
   }
 
-  std::string RulePrivate::toString(bool invalid) const
+  std::string RulePrivate::toString(bool invalid, bool hide_pii) const
   {
     std::string rule_string;
 
@@ -437,10 +437,18 @@ namespace usbguard
     }
 
     toString_appendNonEmptyAttribute(rule_string, _device_id);
-    toString_appendNonEmptyAttribute(rule_string, _serial);
+
+    if (!hide_pii) {
+      toString_appendNonEmptyAttribute(rule_string, _serial);
+    }
+
     toString_appendNonEmptyAttribute(rule_string, _name);
-    toString_appendNonEmptyAttribute(rule_string, _hash);
-    toString_appendNonEmptyAttribute(rule_string, _parent_hash);
+
+    if (!hide_pii) {
+      toString_appendNonEmptyAttribute(rule_string, _hash);
+      toString_appendNonEmptyAttribute(rule_string, _parent_hash);
+    }
+
     toString_appendNonEmptyAttribute(rule_string, _via_port);
     toString_appendNonEmptyAttribute(rule_string, _with_interface);
     toString_appendNonEmptyAttribute(rule_string, _conditions);

--- a/src/Library/RulePrivate.hpp
+++ b/src/Library/RulePrivate.hpp
@@ -121,7 +121,7 @@ namespace usbguard
     const Rule::Attribute<RuleCondition>& attributeConditions() const;
     Rule::Attribute<RuleCondition>& attributeConditions();
 
-    std::string toString(bool invalid = false) const;
+    std::string toString(bool invalid = false, bool hide_pii = false) const;
 
     MetaData& metadata();
     const MetaData& metadata() const;

--- a/src/Library/public/usbguard/Audit.cpp
+++ b/src/Library/public/usbguard/Audit.cpp
@@ -156,13 +156,18 @@ namespace usbguard
   }
 
   Audit::Audit(const AuditIdentity& identity)
-    : _identity(identity)
+    : _identity(identity), _hide_pii(false)
   {
   }
 
   void Audit::setBackend(std::unique_ptr<AuditBackend> backend)
   {
     _backend = std::shared_ptr<AuditBackend>(std::move(backend));
+  }
+
+  void Audit::setHidePII(bool hide_pii)
+  {
+    _hide_pii = hide_pii;
   }
 
   AuditEvent Audit::policyEvent(std::shared_ptr<Rule> rule, Policy::EventType event)
@@ -200,7 +205,7 @@ namespace usbguard
     AuditEvent event(identity, _backend);
     event.setKey("type", std::string("Policy.") + Policy::eventTypeToString(event_type));
     event.setKey("rule.id", numberToString(rule->getRuleID()));
-    event.setKey("rule", rule->toString());
+    event.setKey("rule", rule->toString(false, _hide_pii));
     return event;
   }
 
@@ -209,8 +214,8 @@ namespace usbguard
     AuditEvent event(identity, _backend);
     event.setKey("type", std::string("Policy.") + Policy::eventTypeToString(Policy::EventType::Update));
     event.setKey("rule.id", numberToString(old_rule->getRuleID()));
-    event.setKey("rule.old", old_rule->toString());
-    event.setKey("rule.new", new_rule->toString());
+    event.setKey("rule.old", old_rule->toString(false, _hide_pii));
+    event.setKey("rule.new", new_rule->toString(false, _hide_pii));
     return event;
   }
 
@@ -220,7 +225,7 @@ namespace usbguard
     event.setKey("type", std::string("Policy.Device.") + Policy::eventTypeToString(event_type));
     event.setKey("target", Rule::targetToString(device->getTarget()));
     event.setKey("device.system_name", device->getSystemName());
-    event.setKey("device.rule", device->getDeviceRule()->toString());
+    event.setKey("device.rule", device->getDeviceRule()->toString(false, _hide_pii));
     return event;
   }
 
@@ -232,7 +237,7 @@ namespace usbguard
     event.setKey("target.old", Rule::targetToString(old_target));
     event.setKey("target.new", Rule::targetToString(new_target));
     event.setKey("device.system_name", device->getSystemName());
-    event.setKey("device.rule", device->getDeviceRule()->toString());
+    event.setKey("device.rule", device->getDeviceRule()->toString(false, _hide_pii));
     return event;
   }
 
@@ -242,7 +247,7 @@ namespace usbguard
     AuditEvent event(identity, _backend);
     event.setKey("type", std::string("Device.") + DeviceManager::eventTypeToString(event_type));
     event.setKey("device.system_name", device->getSystemName());
-    event.setKey("device.rule", device->getDeviceRule()->toString());
+    event.setKey("device.rule", device->getDeviceRule()->toString(false, _hide_pii));
     return event;
   }
 
@@ -252,8 +257,8 @@ namespace usbguard
     AuditEvent event(identity, _backend);
     event.setKey("type", std::string("Device.") + DeviceManager::eventTypeToString(DeviceManager::EventType::Update));
     event.setKey("device.system_name", new_device->getSystemName());
-    event.setKey("device.rule.old", old_device->getDeviceRule()->toString());
-    event.setKey("device.rule.new", new_device->getDeviceRule()->toString());
+    event.setKey("device.rule.old", old_device->getDeviceRule()->toString(false, _hide_pii));
+    event.setKey("device.rule.new", new_device->getDeviceRule()->toString(false, _hide_pii));
     return event;
   }
 } /* namespace usbguard */

--- a/src/Library/public/usbguard/Audit.hpp
+++ b/src/Library/public/usbguard/Audit.hpp
@@ -104,6 +104,13 @@ namespace usbguard
 
     void setBackend(std::unique_ptr<AuditBackend> backend);
 
+    /*
+     * Sets whether personally identifiable information such as device serial
+     * numbers and hashes of the descriptors (which include the serial number)
+     * should be excluded from audit entries.
+     */
+    void setHidePII(bool hide_pii);
+
     AuditEvent policyEvent(std::shared_ptr<Rule> rule, Policy::EventType event);
     AuditEvent policyEvent(std::shared_ptr<Rule> new_rule, std::shared_ptr<Rule> old_rule);
     AuditEvent policyEvent(std::shared_ptr<Device> device, Policy::EventType event);
@@ -149,6 +156,7 @@ namespace usbguard
   private:
     AuditIdentity _identity;
     std::shared_ptr<AuditBackend> _backend;
+    bool _hide_pii;
   };
 } /* namespace usbguard */
 

--- a/src/Library/public/usbguard/Rule.cpp
+++ b/src/Library/public/usbguard/Rule.cpp
@@ -243,9 +243,9 @@ namespace usbguard
         getTarget() == Target::Empty);
   }
 
-  std::string Rule::toString(bool invalid) const
+  std::string Rule::toString(bool invalid, bool hide_serial) const
   {
-    return d_pointer->toString(invalid);
+    return d_pointer->toString(invalid, hide_serial);
   }
 
   void Rule::updateMetaDataCounters(bool applied, bool evaluated)

--- a/src/Library/public/usbguard/Rule.hpp
+++ b/src/Library/public/usbguard/Rule.hpp
@@ -487,7 +487,7 @@ namespace usbguard
 
 
     operator bool() const;
-    std::string toString(bool invalid = false) const;
+    std::string toString(bool invalid = false, bool hide_serial = false) const;
 
     void updateMetaDataCounters(bool applied = true, bool evaluated = false);
 


### PR DESCRIPTION
This new configuration option excludes USB device serial numbers and
the devices hashes (which include the serial number) from being
logged to the Audit backend. This is useful when you want the audit
entries without PII to be writen to the syslog.