### PR TITLE
Add PropertyParameterChanged signal

### DIFF
--- a/src/CLI/IPCSignalWatcher.cpp
+++ b/src/CLI/IPCSignalWatcher.cpp
@@ -127,6 +127,25 @@ namespace usbguard
     }
   }
 
+  void IPCSignalWatcher::PropertyParameterChanged(const std::string& name,
+    const std::string& value_old,
+    const std::string& value_new)
+  {
+    std::cout << "[property] ParameterChanged: name=" << name << std::endl;
+    std::cout << " value_old=" << value_old << std::endl;
+    std::cout << " value_new=" << value_new << std::endl;
+
+    if (hasOpenExecutable()) {
+      const std::map<std::string, std::string> env = {
+        { "USBGUARD_IPC_SIGNAL", "Property.ParameterChanged" },
+        { "USBGUARD_PROPERTY_NAME", name },
+        { "USBGUARD_PROPERTY_VALUE_OLD", value_old },
+        { "USBGUARD_PROPERTY_VALUE_NEW", value_new }
+      };
+      runExecutable(env);
+    }
+  }
+
   void IPCSignalWatcher::openExecutable(const std::string& path)
   {
     const int fd = ::open(path.c_str(), O_RDONLY);

--- a/src/CLI/IPCSignalWatcher.hpp
+++ b/src/CLI/IPCSignalWatcher.hpp
@@ -45,6 +45,10 @@ namespace usbguard
       Rule::Target target_new,
       const std::string& device_rule,
       uint32_t rule_id) override;
+
+    void PropertyParameterChanged(const std::string& name,
+      const std::string& value_old,
+      const std::string& value_new) override;
   private:
     void openExecutable(const std::string& path);
     void closeExecutable();

--- a/src/DBus/DBusBridge.cpp
+++ b/src/DBus/DBusBridge.cpp
@@ -271,6 +271,19 @@ namespace usbguard
     }
   }
 
+  void DBusBridge::PropertyParameterChanged(const std::string& name,
+    const std::string& value_old,
+    const std::string& value_new)
+  {
+    g_dbus_connection_emit_signal(p_gdbus_connection, nullptr,
+      "/org/usbguard", "org.usbguard", "PropertyParameterChanged",
+      g_variant_new("(sss)",
+        name.c_str(),
+        value_old.c_str(),
+        value_new.c_str()),
+      nullptr);
+  }
+
   void DBusBridge::ExceptionMessage(const std::string& context,
     const std::string& object,
     const std::string& reason)

--- a/src/DBus/DBusBridge.hpp
+++ b/src/DBus/DBusBridge.hpp
@@ -55,6 +55,10 @@ namespace usbguard
       const std::string& device_rule,
       uint32_t rule_id) override;
 
+    void PropertyParameterChanged(const std::string& name,
+      const std::string& value_old,
+      const std::string& value_new) override;
+
     void ExceptionMessage(const std::string& context,
       const std::string& object,
       const std::string& reason) override;

--- a/src/DBus/DBusInterface.xml
+++ b/src/DBus/DBusInterface.xml
@@ -27,6 +27,22 @@
       <arg name="value" direction="in" type="s"/>
       <arg name="previous_value" direction="out" type="s"/>
     </method>
+
+    <!--
+      PropertyParameterChanged:
+       @name: Policy name
+       @value_old: Previous policy value.
+       @value_new: Current policy value.
+
+        Notify about a change of a property parameter.
+
+      -->
+    <signal name="PropertyParameterChanged">
+      <arg name="name" direction="out" type="s"/>
+      <arg name="value_old" direction="out" type="s"/>
+      <arg name="value_new" direction="out" type="s"/>
+    </signal>
+
     <!--
       ExceptionMessage:
       @context: Description or identifier of the exception context.

--- a/src/Daemon/Daemon.cpp
+++ b/src/Daemon/Daemon.cpp
@@ -633,6 +633,9 @@ namespace usbguard
     if (name == "InsertedDevicePolicy") {
       const auto previous_value = devicePolicyMethodToString(_inserted_device_policy_method);
       setInsertedDevicePolicyMethod(devicePolicyMethodFromString(value));
+      PropertyParameterChanged(name,
+        previous_value,
+        value);
       return previous_value;
     }
 

--- a/src/Library/IPC/Devices.proto
+++ b/src/Library/IPC/Devices.proto
@@ -50,3 +50,9 @@ message DevicePolicyChangedSignal {
   required string device_rule = 4;
   required uint32 rule_id = 5;
 }
+
+message PropertyParameterChangedSignal {
+  required string name = 1;
+  required string value_old = 2;
+  required string value_new = 3;
+}

--- a/src/Library/IPCClientPrivate.cpp
+++ b/src/Library/IPCClientPrivate.cpp
@@ -83,6 +83,7 @@ namespace usbguard
     registerHandler<IPC::Exception>(&IPCClientPrivate::handleException);
     registerHandler<IPC::DevicePresenceChangedSignal>(&IPCClientPrivate::handleDevicePresenceChangedSignal);
     registerHandler<IPC::DevicePolicyChangedSignal>(&IPCClientPrivate::handleDevicePolicyChangedSignal);
+    registerHandler<IPC::PropertyParameterChangedSignal>(&IPCClientPrivate::handlePropertyParameterChangedSignal);
 
     if (connected) {
       try {
@@ -507,6 +508,16 @@ namespace usbguard
       Rule::targetFromInteger(signal->target_new()),
       signal->device_rule(),
       signal->rule_id());
+  }
+
+  void IPCClientPrivate::handlePropertyParameterChangedSignal(IPC::MessagePointer& message_in, IPC::MessagePointer& message_out)
+  {
+    (void)message_out;
+    const IPC::PropertyParameterChangedSignal* const signal = \
+      reinterpret_cast<const IPC::PropertyParameterChangedSignal*>(message_in.get());
+    _p_instance.PropertyParameterChanged(signal->name(),
+      signal->value_old(),
+      signal->value_new());
   }
 } /* namespace usbguard */
 

--- a/src/Library/IPCClientPrivate.hpp
+++ b/src/Library/IPCClientPrivate.hpp
@@ -107,6 +107,7 @@ namespace usbguard
     void handleException(IPC::MessagePointer& message_in, IPC::MessagePointer& message_out);
     void handleDevicePresenceChangedSignal(IPC::MessagePointer& message_in, IPC::MessagePointer& message_out);
     void handleDevicePolicyChangedSignal(IPC::MessagePointer& message_in, IPC::MessagePointer& message_out);
+    void handlePropertyParameterChangedSignal(IPC::MessagePointer& message_in, IPC::MessagePointer& message_out);
 
     IPCClient& _p_instance;
 

--- a/src/Library/IPCPrivate.cpp
+++ b/src/Library/IPCPrivate.cpp
@@ -38,12 +38,13 @@ namespace usbguard
     { 0x02, "usbguard.IPC.applyDevicePolicy" },
     { 0x03, "usbguard.IPC.DevicePresenceChangedSignal" },
     { 0x04, "usbguard.IPC.DevicePolicyChangedSignal" },
-    { 0x05, "usbguard.IPC.listRules" },
-    { 0x06, "usbguard.IPC.appendRule" },
-    { 0x07, "usbguard.IPC.removeRule" },
-    { 0x08, "usbguard.IPC.Exception" },
-    { 0x09, "usbguard.IPC.getParameter" },
-    { 0x0a, "usbguard.IPC.setParameter" }
+    { 0x05, "usbguard.IPC.PropertyParameterChangedSignal" },
+    { 0x06, "usbguard.IPC.listRules" },
+    { 0x07, "usbguard.IPC.appendRule" },
+    { 0x08, "usbguard.IPC.removeRule" },
+    { 0x09, "usbguard.IPC.Exception" },
+    { 0x0a, "usbguard.IPC.getParameter" },
+    { 0x0b, "usbguard.IPC.setParameter" }
   };
 
   uint32_t IPC::messageTypeNameToNumber(const std::string& name)

--- a/src/Library/IPCServerPrivate.cpp
+++ b/src/Library/IPCServerPrivate.cpp
@@ -533,6 +533,10 @@ namespace usbguard
       return IPCServer::AccessControl::Section::DEVICES;
     }
 
+    if (name == "usbguard.IPC.PropertyParameterChangedSignal") {
+      return IPCServer::AccessControl::Section::PARAMETERS;
+    }
+
     if (name == "usbguard.IPC.Exception") {
       return IPCServer::AccessControl::Section::EXCEPTIONS;
     }
@@ -1012,6 +1016,17 @@ namespace usbguard
     signal.set_target_new(Rule::targetToInteger(target_new));
     signal.set_device_rule(device_rule);
     signal.set_rule_id(rule_id);
+    qbIPCBroadcastMessage(&signal);
+  }
+
+  void IPCServerPrivate::PropertyParameterChanged(const std::string& name,
+    const std::string& value_old,
+    const std::string& value_new)
+  {
+    IPC::PropertyParameterChangedSignal signal;
+    signal.set_name(name);
+    signal.set_value_old(value_old);
+    signal.set_value_new(value_new);
     qbIPCBroadcastMessage(&signal);
   }
 

--- a/src/Library/IPCServerPrivate.hpp
+++ b/src/Library/IPCServerPrivate.hpp
@@ -63,6 +63,10 @@ namespace usbguard
       const std::string& device_rule,
       uint32_t rule_id);
 
+    void PropertyParameterChanged(const std::string& name,
+      const std::string& value_old,
+      const std::string& value_new);
+
     void ExceptionMessage(const std::string& context,
       const std::string& object,
       const std::string& reason,

--- a/src/Library/public/usbguard/IPCClient.hpp
+++ b/src/Library/public/usbguard/IPCClient.hpp
@@ -93,6 +93,15 @@ namespace usbguard
       (void)rule_id;
     }
 
+    virtual void PropertyParameterChanged(const std::string& name,
+      const std::string& value_old,
+      const std::string& value_new) override
+    {
+      (void)name;
+      (void)value_old;
+      (void)value_new;
+    }
+
     virtual void ExceptionMessage(const std::string& context,
       const std::string& object,
       const std::string& reason) override

--- a/src/Library/public/usbguard/IPCServer.cpp
+++ b/src/Library/public/usbguard/IPCServer.cpp
@@ -284,6 +284,13 @@ namespace usbguard
     d_pointer->DevicePolicyChanged(id, target_old, target_new, device_rule, rule_id);
   }
 
+  void IPCServer::PropertyParameterChanged(const std::string& name,
+    const std::string& value_old,
+    const std::string& value_new)
+  {
+    d_pointer->PropertyParameterChanged(name, value_old, value_new);
+  }
+
   void IPCServer::ExceptionMessage(const std::string& context,
     const std::string& object,
     const std::string& reason)

--- a/src/Library/public/usbguard/IPCServer.hpp
+++ b/src/Library/public/usbguard/IPCServer.hpp
@@ -111,6 +111,10 @@ namespace usbguard
       const std::string& device_rule,
       uint32_t rule_id);
 
+    void PropertyParameterChanged(const std::string& name,
+      const std::string& value_old,
+      const std::string& value_new);
+
     void ExceptionMessage(const std::string& context,
       const std::string& object,
       const std::string& reason);

--- a/src/Library/public/usbguard/Interface.hpp
+++ b/src/Library/public/usbguard/Interface.hpp
@@ -65,6 +65,10 @@ namespace usbguard
       const std::string& device_rule,
       uint32_t rule_id) = 0;
 
+    virtual void PropertyParameterChanged(const std::string& name,
+      const std::string& value_old,
+      const std::string& value_new) = 0;
+
     virtual void ExceptionMessage(const std::string& context,
       const std::string& object,
       const std::string& reason) = 0;


### PR DESCRIPTION
This PR adds a signal when a parameter gets changed.
In this way an application/script can display the current value of a property without using a `get-parameter` polling. 