### PR TITLE
Made the netlink socket and thread optional for UEventDeviceManager.

### DIFF
--- a/src/CLI/PolicyGenerator.cpp
+++ b/src/CLI/PolicyGenerator.cpp
@@ -38,7 +38,6 @@ namespace usbguard
     _catchall_target = Rule::Target::Block;
     _dm = DeviceManager::create(*this, "uevent");
     _dm->setEnumerationOnlyMode(true);
-    _dm->start();
   }
 
   void PolicyGenerator::setWithHashAttribute(bool state)
@@ -64,6 +63,7 @@ namespace usbguard
   void PolicyGenerator::generate()
   {
     if (_devpath.empty()) {
+      _dm->start();
       _dm->scan();
     }
     else {


### PR DESCRIPTION
Now when invoking usbguard generate-policy -d ${devpath}, no netlink
socket or listener thread is spawned. This removes a race condition
where a device connecting while scan(devpath) was executing might be
included in the policy list.