### PR TITLE
set PresentDevicePolicy to allow by default

### DIFF
--- a/usbguard-daemon.conf.in
+++ b/usbguard-daemon.conf.in
@@ -34,8 +34,7 @@ ImplicitPolicyTarget=block
 # * apply-policy - evaluate the ruleset for every present
 #                  device
 #
-PresentDevicePolicy=apply-policy
-
+PresentDevicePolicy=allow
 #
 # Present controller policy.
 #


### PR DESCRIPTION
This is arguably making it more usable, because it prevents users from being locked out. With the user installing USBGuard through their package manager, the daemon is started as well. With the current default configuration the user is then locked out of their system without a way to configure the daemon.

This change attempts to make it more user friendly by not blocking existing devices by default.  It is a compromise of security there as the attacker now needs to wait for a reboot, only. But I think we ought to err on the side of usability in this case.