### PR TITLE
Add properly checking config before saving

### DIFF
--- a/src/Library/ConfigFilePrivate.cpp
+++ b/src/Library/ConfigFilePrivate.cpp
@@ -104,7 +104,7 @@ namespace usbguard
 
   void ConfigFilePrivate::close()
   {
-    if (_stream) {
+    if (_stream.is_open()) {
       if (_dirty && !_readonly) {
         write();
       }


### PR DESCRIPTION
This fix will correctly check if the stream is open before saving the
new config file if your config file is not readonly.