### PR TITLE
Add temporary option to append-rule

### DIFF
--- a/src/CLI/usbguard-append-rule.cpp
+++ b/src/CLI/usbguard-append-rule.cpp
@@ -29,11 +29,12 @@
 
 namespace usbguard
 {
-  static const char* options_short = "ha:";
+  static const char* options_short = "ha:t";
 
   static const struct ::option options_long[] = {
     { "help", no_argument, nullptr, 'h' },
     { "after", required_argument, nullptr, 'a' },
+    { "temporary", no_argument, nullptr, 't' },
     { nullptr, 0, nullptr, 0 }
   };
 
@@ -44,6 +45,8 @@ namespace usbguard
     stream << " Options:" << std::endl;
     stream << "  -a, --after <id>  Append the new rule after a rule with the specified id" << std::endl;
     stream << "                    instead of appending it at the end of the rule set." << std::endl;
+    stream << "  -t, --temporary   Make the decision temporary. The rule policy file will not" << std::endl;
+    stream << "                    be updated." << std::endl;
     stream << "  -h, --help        Show this help." << std::endl;
     stream << std::endl;
   }
@@ -51,6 +54,7 @@ namespace usbguard
   int usbguard_append_rule(int argc, char* argv[])
   {
     uint32_t parent_id = usbguard::Rule::LastID;
+    bool permanent = true;
     int opt = 0;
 
     while ((opt = getopt_long(argc, argv, options_short, options_long, nullptr)) != -1) {
@@ -61,6 +65,10 @@ namespace usbguard
 
       case 'a':
         parent_id = std::stoul(optarg);
+        break;
+
+      case 't':
+        permanent = false;
         break;
 
       case '?':
@@ -81,7 +89,7 @@ namespace usbguard
 
     usbguard::IPCClient ipc(/*connected=*/true);
     const std::string rule_spec = argv[0];
-    const uint32_t id = ipc.appendRule(rule_spec, parent_id);
+    const uint32_t id = ipc.appendRule(rule_spec, parent_id, permanent);
     std::cout << id << std::endl;
     return EXIT_SUCCESS;
   }

--- a/src/DBus/DBusBridge.cpp
+++ b/src/DBus/DBusBridge.cpp
@@ -140,9 +140,10 @@ namespace usbguard
     if (method_name == "appendRule") {
       const char* rule_spec_cstr = nullptr;
       uint32_t parent_id = 0;
-      g_variant_get(parameters, "(&su)", &rule_spec_cstr, &parent_id);
+      bool temporary = false;
+      g_variant_get(parameters, "(&sub)", &rule_spec_cstr, &parent_id, &temporary);
       std::string rule_spec(rule_spec_cstr);
-      const uint32_t rule_id = appendRule(rule_spec, parent_id);
+      const uint32_t rule_id = appendRule(rule_spec, parent_id, !temporary);
       g_dbus_method_invocation_return_value(invocation, g_variant_new("(u)", rule_id));
       return;
     }

--- a/src/DBus/DBusInterface.xml
+++ b/src/DBus/DBusInterface.xml
@@ -78,6 +78,7 @@
       appendRule:
        @rule: The rule that should be appended to the policy.
        @parent_id: Rule id of the parent rule.
+       @temporary: A boolean to avoid adding this rule to the policy file.
        @id: The rule id assigned to the succesfully appended rule.
 
       Append a new rule to the current policy. Using the parent_id
@@ -88,6 +89,7 @@
     <method name="appendRule">
       <arg name="rule" direction="in" type="s"/>
       <arg name="parent_id" direction="in" type="u"/>
+      <arg name="temporary" direction="in" type="b"/>
       <arg name="id" direction="out" type="u"/>
     </method>
 

--- a/src/Daemon/Daemon.cpp
+++ b/src/Daemon/Daemon.cpp
@@ -687,7 +687,7 @@ namespace usbguard
   }
 
   uint32_t Daemon::appendRule(const std::string& rule_spec,
-    uint32_t parent_id)
+    uint32_t parent_id, bool permanent)
   {
     USBGUARD_LOG(Trace) << "entry:"
       << " rule_spec=" << rule_spec
@@ -696,7 +696,7 @@ namespace usbguard
     /* TODO: reevaluate the firewall rules for all active devices */
     const uint32_t id = _policy.getRuleSet()->appendRule(rule, parent_id);
 
-    if (_config.hasSettingValue("RuleFile")) {
+    if (_config.hasSettingValue("RuleFile") && permanent) {
       _policy.getRuleSet()->save();
     }
 

--- a/src/Daemon/Daemon.hpp
+++ b/src/Daemon/Daemon.hpp
@@ -88,7 +88,7 @@ namespace usbguard
     std::string setParameter(const std::string& name, const std::string& value) override;
     std::string getParameter(const std::string& name) override;
 
-    uint32_t appendRule(const std::string& rule_spec, uint32_t parent_id) override;
+    uint32_t appendRule(const std::string& rule_spec, uint32_t parent_id, bool permanent) override;
     void removeRule(uint32_t id) override;
     const std::shared_ptr<RuleSet> listRules(const std::string& query) override;
 

--- a/src/Library/IPC/Policy.proto
+++ b/src/Library/IPC/Policy.proto
@@ -22,6 +22,7 @@ message listRules {
 message appendRuleRequest {
   required string rule = 1;
   required uint32 parent_id = 2;
+  required bool permanent = 3;
 }
 
 message appendRuleResponse {

--- a/src/Library/IPCClientPrivate.cpp
+++ b/src/Library/IPCClientPrivate.cpp
@@ -380,11 +380,12 @@ namespace usbguard
     return message_in->response().value();
   }
 
-  uint32_t IPCClientPrivate::appendRule(const std::string& rule_spec, uint32_t parent_id)
+  uint32_t IPCClientPrivate::appendRule(const std::string& rule_spec, uint32_t parent_id, bool permanent)
   {
     IPC::appendRule message_out;
     message_out.mutable_request()->set_rule(rule_spec);
     message_out.mutable_request()->set_parent_id(parent_id);
+    message_out.mutable_request()->set_permanent(permanent);
     auto message_in = qbIPCSendRecvMessage(message_out);
     return message_in->response().id();
   }

--- a/src/Library/IPCClientPrivate.hpp
+++ b/src/Library/IPCClientPrivate.hpp
@@ -58,7 +58,7 @@ namespace usbguard
     std::string setParameter(const std::string& name, const std::string& value);
     std::string getParameter(const std::string& name);
 
-    uint32_t appendRule(const std::string& rule_spec, uint32_t parent_id);
+    uint32_t appendRule(const std::string& rule_spec, uint32_t parent_id, bool permanent);
     void removeRule(uint32_t id);
     const std::shared_ptr<RuleSet> listRules(const std::string& query);
 

--- a/src/Library/IPCServerPrivate.cpp
+++ b/src/Library/IPCServerPrivate.cpp
@@ -848,10 +848,11 @@ namespace usbguard
     const IPC::appendRule* const message_in = static_cast<const IPC::appendRule*>(request.get());
     const std::string rule = message_in->request().rule();
     const uint32_t parent_id = message_in->request().parent_id();
+    const bool permanent = message_in->request().permanent();
     /*
      * Execute the method.
      */
-    const uint32_t id = _p_instance.appendRule(rule, parent_id);
+    const uint32_t id = _p_instance.appendRule(rule, parent_id, permanent);
     /*
      * Construct the response.
      */

--- a/src/Library/public/usbguard/IPCClient.cpp
+++ b/src/Library/public/usbguard/IPCClient.cpp
@@ -62,9 +62,9 @@ namespace usbguard
     return d_pointer->getParameter(name);
   }
 
-  uint32_t IPCClient::appendRule(const std::string& rule_spec, uint32_t parent_id)
+  uint32_t IPCClient::appendRule(const std::string& rule_spec, uint32_t parent_id, bool permanent)
   {
-    return d_pointer->appendRule(rule_spec, parent_id);
+    return d_pointer->appendRule(rule_spec, parent_id, permanent);
   }
 
   void IPCClient::removeRule(uint32_t id)

--- a/src/Library/public/usbguard/IPCClient.hpp
+++ b/src/Library/public/usbguard/IPCClient.hpp
@@ -46,7 +46,7 @@ namespace usbguard
     std::string setParameter(const std::string& name, const std::string& value) override;
     std::string getParameter(const std::string& name) override;
 
-    uint32_t appendRule(const std::string& rule_spec, uint32_t parent_id) override;
+    uint32_t appendRule(const std::string& rule_spec, uint32_t parent_id, bool permanent) override;
     void removeRule(uint32_t id) override;
     const std::shared_ptr<RuleSet> listRules(const std::string& query) override;
     const std::shared_ptr<RuleSet> listRules()

--- a/src/Library/public/usbguard/Interface.hpp
+++ b/src/Library/public/usbguard/Interface.hpp
@@ -41,7 +41,7 @@ namespace usbguard
 
     /* Methods */
     virtual uint32_t appendRule(const std::string& rule_spec,
-      uint32_t parent_id) = 0;
+      uint32_t parent_id, bool permanent) = 0;
 
     virtual void removeRule(uint32_t id) = 0;
 


### PR DESCRIPTION
Similarly to the -p (permanent) option of allow-device, this commit adds the option to append a rule only temporary. I have kept the name as "permanent" on the service side but exposed as the opposite (temporary) on the CLI to match the current default behavior (that is, appending is currently permanent).