### PR TITLE
Remove _default_action attribute from RuleSet

### DIFF
--- a/src/Library/public/usbguard/Policy.cpp
+++ b/src/Library/public/usbguard/Policy.cpp
@@ -51,11 +51,6 @@ namespace usbguard
     return _ruleset_ptr->getDefaultTarget();
   }
 
-  void Policy::setDefaultAction(const std::string& action)
-  {
-    _ruleset_ptr->setDefaultAction(action);
-  }
-
   uint32_t Policy::appendRule(const Rule& rule, uint32_t parent_id)
   {
     return _ruleset_ptr->appendRule(rule, parent_id);

--- a/src/Library/public/usbguard/RuleSet.cpp
+++ b/src/Library/public/usbguard/RuleSet.cpp
@@ -38,7 +38,6 @@ namespace usbguard
   {
     clearWritable();
     _default_target = Rule::Target::Block;
-    _default_action = std::string();
     _id_next = Rule::RootID + 1;
   }
 
@@ -51,7 +50,6 @@ namespace usbguard
   {
     _interface_ptr = rhs._interface_ptr;
     _default_target = rhs._default_target;
-    _default_action = rhs._default_action;
     _id_next = rhs._id_next.load();
     _rules = rhs._rules;
     return *this;
@@ -67,12 +65,6 @@ namespace usbguard
   {
     std::unique_lock<std::mutex> op_lock(_op_mutex);
     return _default_target;
-  }
-
-  void RuleSet::setDefaultAction(const std::string& action)
-  {
-    std::unique_lock<std::mutex> op_lock(_op_mutex);
-    _default_action = action;
   }
 
   uint32_t RuleSet::appendRule(const Rule& rule, uint32_t parent_id, bool lock)

--- a/src/Library/public/usbguard/RuleSet.hpp
+++ b/src/Library/public/usbguard/RuleSet.hpp
@@ -43,7 +43,6 @@ namespace usbguard
 
     void setDefaultTarget(Rule::Target target);
     Rule::Target getDefaultTarget() const;
-    void setDefaultAction(const std::string& action);
     uint32_t appendRule(const Rule& rule, uint32_t parent_id = Rule::LastID, bool lock = true);
     uint32_t upsertRule(const Rule& match_rule, const Rule& new_rule, bool parent_insensitive = false);
     std::shared_ptr<Rule> getRule(uint32_t id);
@@ -66,7 +65,6 @@ namespace usbguard
 
     Interface* _interface_ptr{nullptr};
     Rule::Target _default_target;
-    std::string _default_action;
     Atomic<uint32_t> _id_next;
     std::vector<std::shared_ptr<Rule>> _rules;
   };


### PR DESCRIPTION
The _default_action attribute is not currently used and appears to be a functional duplicate of _default_target. Remove it and the associated methods.