### PR TITLE
Add label to rules

### DIFF
--- a/src/DBus/DBusBridge.cpp
+++ b/src/DBus/DBusBridge.cpp
@@ -108,8 +108,7 @@ namespace usbguard
       const char* query_cstr = nullptr;
       g_variant_get(parameters, "(&s)", &query_cstr);
       std::string query(query_cstr);
-      auto rule_set = listRules(query);
-      auto rules = rule_set->getRules();
+      auto rules = listRules(query);
 
       if (rules.size() > 0) {
         auto gvbuilder = g_variant_builder_new(G_VARIANT_TYPE_ARRAY);
@@ -117,8 +116,8 @@ namespace usbguard
         try {
           for (auto rule : rules) {
             g_variant_builder_add(gvbuilder, "(us)",
-              rule->getRuleID(),
-              rule->toString().c_str());
+              rule.getRuleID(),
+              rule.toString().c_str());
           }
 
           g_dbus_method_invocation_return_value(invocation, g_variant_new("(a(us))", gvbuilder));

--- a/src/Daemon/Daemon.cpp
+++ b/src/Daemon/Daemon.cpp
@@ -718,10 +718,19 @@ namespace usbguard
     }
   }
 
-  const std::shared_ptr<RuleSet> Daemon::listRules(const std::string& query)
+  const std::vector<Rule> Daemon::listRules(const std::string& query)
   {
     USBGUARD_LOG(Trace) << "entry: query=" << query;
-    return _policy.getRuleSet();
+    std::vector<Rule> rules;
+
+    for(auto const& rule : _policy.getRuleSet()->getRules()) {
+      if (query.empty() || rule->getLabel() == query) {
+        rules.push_back(*rule);
+      }
+    }
+
+    USBGUARD_LOG(Trace) << "return:" << " count(rules)=" << rules.size();
+    return rules;
   }
 
   uint32_t Daemon::applyDevicePolicy(uint32_t id, Rule::Target target, bool permanent)

--- a/src/Daemon/Daemon.hpp
+++ b/src/Daemon/Daemon.hpp
@@ -90,7 +90,7 @@ namespace usbguard
 
     uint32_t appendRule(const std::string& rule_spec, uint32_t parent_id, bool permanent) override;
     void removeRule(uint32_t id) override;
-    const std::shared_ptr<RuleSet> listRules(const std::string& query) override;
+    const std::vector<Rule> listRules(const std::string& query) override;
 
     uint32_t applyDevicePolicy(uint32_t id, Rule::Target target, bool permanent) override;
     const std::vector<Rule> listDevices(const std::string& query) override;

--- a/src/Library/IPC/Policy.proto
+++ b/src/Library/IPC/Policy.proto
@@ -8,8 +8,7 @@ message listRulesRequest {
 }
 
 message listRulesResponse {
-  required uint32 default_target = 1;
-  repeated Rule rules = 2;
+  repeated Rule rules = 1;
 }
 
 message listRules {

--- a/src/Library/IPCClientPrivate.hpp
+++ b/src/Library/IPCClientPrivate.hpp
@@ -60,7 +60,7 @@ namespace usbguard
 
     uint32_t appendRule(const std::string& rule_spec, uint32_t parent_id, bool permanent);
     void removeRule(uint32_t id);
-    const std::shared_ptr<RuleSet> listRules(const std::string& query);
+    const std::vector<Rule> listRules(const std::string& query);
 
     uint32_t applyDevicePolicy(uint32_t id, Rule::Target target, bool permanent);
     const std::vector<Rule> listDevices(const std::string& query);

--- a/src/Library/IPCServerPrivate.cpp
+++ b/src/Library/IPCServerPrivate.cpp
@@ -892,19 +892,17 @@ namespace usbguard
     /*
      * Execute the method.
      */
-    auto rule_set = _p_instance.listRules(query);
-    const uint32_t default_target = Rule::targetToInteger(rule_set->getDefaultTarget());
+    auto rules = _p_instance.listRules(query);
     /*
      * Construct the response.
      */
     IPC::listRules* const message_out = message_in->New();
     message_out->MergeFrom(*message_in);
-    message_out->mutable_response()->set_default_target(default_target);
 
-    for (const auto& rule : rule_set->getRules()) {
+    for (const auto& rule : rules) {
       auto message_rule = message_out->mutable_response()->add_rules();
-      message_rule->set_id(rule->getRuleID());
-      message_rule->set_rule(rule->toString());
+      message_rule->set_id(rule.getRuleID());
+      message_rule->set_rule(rule.toString());
     }
 
     response.reset(message_out);

--- a/src/Library/RuleParser/Actions.hpp
+++ b/src/Library/RuleParser/Actions.hpp
@@ -311,6 +311,48 @@ namespace usbguard
       }
     };
 
+    template<typename Rule>
+    struct label_actions : tao::pegtl::nothing<Rule> {};
+
+    template<>
+    struct label_actions<str_serial> {
+      template<typename Input>
+      static void apply(const Input& in, Rule& rule)
+      {
+        if (!rule.attributeLabel().empty()) {
+          throw tao::pegtl::parse_error("label attribute already defined", in);
+        }
+      }
+    };
+
+    template<>
+    struct label_actions<string_value> {
+      template<typename Input>
+      static void apply(const Input& in, Rule& rule)
+      {
+        try {
+          rule.attributeLabel().append(stringValueFromRule(in.string()));
+        }
+        catch (const std::exception& ex) {
+          throw tao::pegtl::parse_error(ex.what(), in);
+        }
+      }
+    };
+
+    template<>
+    struct label_actions<multiset_operator> {
+      template<typename Input>
+      static void apply(const Input& in, Rule& rule)
+      {
+        try {
+          rule.attributeLabel().setSetOperator(Rule::setOperatorFromString(in.string()));
+        }
+        catch (const std::exception& ex) {
+          throw tao::pegtl::parse_error(ex.what(), in);
+        }
+      }
+    };
+
     template <typename Rule>
     struct with_connect_type_actions : tao::pegtl::nothing<Rule> {};
 

--- a/src/Library/RuleParser/Grammar.hpp
+++ b/src/Library/RuleParser/Grammar.hpp
@@ -48,6 +48,7 @@ namespace usbguard
     struct str_serial : TAOCPP_PEGTL_STRING("serial") {};
     struct str_if : TAOCPP_PEGTL_STRING("if") {};
     struct str_id : TAOCPP_PEGTL_STRING("id") {};
+    struct str_label : TAOCPP_PEGTL_STRING("label") {};
 
     struct str_all_of : TAOCPP_PEGTL_STRING("all-of") {};
     struct str_one_of : TAOCPP_PEGTL_STRING("one-of") {};
@@ -176,6 +177,9 @@ namespace usbguard
     struct condition_attribute
       : action<condition_actions, rule_attribute<str_if, condition>> {};
 
+    struct label_attribute
+      : action<label_actions, rule_attribute<str_label, string_value>> {};
+
     struct rule_attributes
       : sor<id_attribute,
         name_attribute,
@@ -185,7 +189,8 @@ namespace usbguard
         via_port_attribute,
         with_interface_attribute,
         with_connect_type_attribute,
-        condition_attribute> {};
+        condition_attribute,
+        label_attribute> {};
 
     /*
      * Rule target

--- a/src/Library/RulePrivate.cpp
+++ b/src/Library/RulePrivate.cpp
@@ -38,7 +38,8 @@ namespace usbguard
       _parent_hash("parent-hash"),
       _via_port("via-port"),
       _with_interface("with-interface"),
-      _conditions("if")
+      _conditions("if"),
+      _label("label")
   {
     (void)p_instance;
     _rule_id = Rule::DefaultID;
@@ -56,7 +57,8 @@ namespace usbguard
       _parent_hash("parent-hash"),
       _via_port("via-port"),
       _with_interface("with-interface"),
-      _conditions("if")
+      _conditions("if"),
+      _label("label")
   {
     (void)p_instance;
     *this = rhs;
@@ -77,6 +79,7 @@ namespace usbguard
     _with_interface = rhs._with_interface;
     _conditions = rhs._conditions;
     _conditions_state = rhs._conditions_state;
+    _label= rhs._label;
     return *this;
 #if 0
 
@@ -312,6 +315,26 @@ namespace usbguard
     return _serial;
   }
 
+  void RulePrivate::setLabel(const std::string& value)
+  {
+    _label.set(value);
+  }
+
+  const std::string& RulePrivate::getLabel() const
+  {
+    return _label.get();
+  }
+
+  const Rule::Attribute<std::string>& RulePrivate::attributeLabel() const
+  {
+    return _label;
+  }
+
+  Rule::Attribute<std::string>& RulePrivate::attributeLabel()
+  {
+    return _label;
+  }
+
   void RulePrivate::setWithConnectType(const std::string& value)
   {
     _with_connect_type.set(value);
@@ -477,6 +500,7 @@ namespace usbguard
     toString_appendNonEmptyAttribute(rule_string, _with_interface);
     toString_appendNonEmptyAttribute(rule_string, _conditions);
     toString_appendNonEmptyAttribute(rule_string, _with_connect_type);
+    toString_appendNonEmptyAttribute(rule_string, _label);
     return rule_string;
   }
 

--- a/src/Library/RulePrivate.hpp
+++ b/src/Library/RulePrivate.hpp
@@ -89,6 +89,11 @@ namespace usbguard
     const Rule::Attribute<std::string>& attributeSerial() const;
     Rule::Attribute<std::string>& attributeSerial();
 
+    void setLabel(const std::string& value);
+    const std::string& getLabel() const;
+    const Rule::Attribute<std::string>& attributeLabel() const;
+    Rule::Attribute<std::string>& attributeLabel();
+
     void setWithConnectType(const std::string& value);
     const std::string& getWithConnectType() const;
     const Rule::Attribute<std::string>& attributeWithConnectType() const;
@@ -149,6 +154,7 @@ namespace usbguard
     Rule::Attribute<std::string> _via_port;
     Rule::Attribute<USBInterfaceType> _with_interface;
     Rule::Attribute<RuleCondition> _conditions;
+    Rule::Attribute<std::string> _label;
     uint64_t _conditions_state;
   };
 }

--- a/src/Library/public/usbguard/IPCClient.cpp
+++ b/src/Library/public/usbguard/IPCClient.cpp
@@ -72,7 +72,7 @@ namespace usbguard
     d_pointer->removeRule(id);
   }
 
-  const std::shared_ptr<RuleSet> IPCClient::listRules(const std::string& query)
+  const std::vector<Rule> IPCClient::listRules(const std::string& query)
   {
     return d_pointer->listRules(query);
   }

--- a/src/Library/public/usbguard/IPCClient.hpp
+++ b/src/Library/public/usbguard/IPCClient.hpp
@@ -48,8 +48,8 @@ namespace usbguard
 
     uint32_t appendRule(const std::string& rule_spec, uint32_t parent_id, bool permanent) override;
     void removeRule(uint32_t id) override;
-    const std::shared_ptr<RuleSet> listRules(const std::string& query) override;
-    const std::shared_ptr<RuleSet> listRules()
+    const std::vector<Rule> listRules(const std::string& query) override;
+    const std::vector<Rule> listRules()
     {
       return listRules("match");
     }

--- a/src/Library/public/usbguard/Interface.hpp
+++ b/src/Library/public/usbguard/Interface.hpp
@@ -45,7 +45,7 @@ namespace usbguard
 
     virtual void removeRule(uint32_t id) = 0;
 
-    virtual const std::shared_ptr<RuleSet> listRules(const std::string& query) = 0;
+    virtual const std::vector<Rule> listRules(const std::string& query) = 0;
 
     virtual uint32_t applyDevicePolicy(uint32_t id,
       Rule::Target target,

--- a/src/Library/public/usbguard/Rule.cpp
+++ b/src/Library/public/usbguard/Rule.cpp
@@ -115,6 +115,26 @@ namespace usbguard
     return d_pointer->attributeSerial();
   }
 
+  void Rule::setLabel(const std::string& value)
+  {
+    d_pointer->setLabel(value);
+  }
+
+  const std::string& Rule::getLabel() const
+  {
+    return d_pointer->getLabel();
+  }
+
+  const Rule::Attribute<std::string>& Rule::attributeLabel() const
+  {
+    return d_pointer->attributeLabel();
+  }
+
+  Rule::Attribute<std::string>& Rule::attributeLabel()
+  {
+    return d_pointer->attributeLabel();
+  }
+
   void Rule::setWithConnectType(const std::string& value)
   {
     d_pointer->setWithConnectType(value);

--- a/src/Library/public/usbguard/Rule.hpp
+++ b/src/Library/public/usbguard/Rule.hpp
@@ -447,6 +447,11 @@ namespace usbguard
     const Attribute<std::string>& attributeSerial() const;
     Attribute<std::string>& attributeSerial();
 
+    void setLabel(const std::string& value);
+    const std::string& getLabel() const;
+    const Attribute<std::string>& attributeLabel() const;
+    Attribute<std::string>& attributeLabel();
+
     void setWithConnectType(const std::string& value);
     const std::string& getWithConnectType() const;
     const Attribute<std::string>& attributeWithConnectType() const;

--- a/src/Tests/Rules/test-rules.good
+++ b/src/Tests/Rules/test-rules.good
@@ -271,6 +271,7 @@ allow with-connect-type { "hardwired" } with-interface { 14:E1:ee a9:ef:1e } nam
 allow with-connect-type one-of { "hotplug" "hardwired" } parent-hash "~5dLGqYl" serial "ti'eurG]"  if false
 allow with-connect-type equals { "unknown" "hotplug" } parent-hash { "W`G.6Y:v" "l',6M , " ".!/r5}Dz" "9HOHPNuk" "k}{N*X%m" "gsr?KNZ8" "OypL42xt" } serial { "dTNG+F-L" "cqomCC/r" "oI7P_=D2" "z~:y^Sgb" } id { 0397:4c5d 0f9d:* } name "{?N|IzD," hash { "$$e]1W6`" }
 allow with-connect-type none-of { "unknown" "hotplug" "not used" } via-port ".sZAu,K#" parent-hash "lR-:Z~S*"
+allow label "arbitrary value"
 block
 block hash "7k9=0w;>" via-port equals { "uAn$>}g'" " Idtdm=Z" "L5+~$p9G" ".<2^/*_#" } name all-of { "CH'-JLED" "A!a^flj}" "VZB4bM29" "zQibW[lk" "~.O];jOw" } id b96e:* with-interface none-of { b8:*:* 1a:fA:* 7e:B6:97 57:*:* 8D:d8:* } serial "&02OlmQ." parent-hash "Y{cAzv[U"
 block hash "8$^jgkWg"


### PR DESCRIPTION
This PR adds a new attribute to the Rule class named "label", as suggested in #283. This attribute can be used to store further background on a rule. For instance, `allow id 045e:00db label "user-preference"`. It is then possible use the command `usbguard list-rules -l "user-preference" ` to only return the rules matching this label.

Worth noticing: 
- The IPC definition of listRules has been simplified to only return `vector<Rule>` (there is currently no client for the default_target attribute, both list-rules and dbus discard that value). If required, this could be implemented in another IPC method).
- The "query" parameter is used directly to store the label. This could be renamed to avoid misunderstandings. I also explored the option of creating a query rule and performing the matching via appliesTo but this changes the semantic of the rule (i.e. any rule without the label would not match anymore). Happy to change this point if another approach makes more sense.
- I dropped the check that a response is necessarily provided (with only optional/repeated fields, this might not be the case). Ideally, this should be implemented within `payloadToMessage` by verifying the returned value of ParseFromString. I would also suggest moving all the required field to optional at some point (reasoning at https://github.com/protocolbuffers/protobuf/issues/2497).