### PR TITLE
[fix] KeyValueParser: validate keys only when known names are set

### DIFF
--- a/src/Library/ConfigFilePrivate.cpp
+++ b/src/Library/ConfigFilePrivate.cpp
@@ -135,7 +135,9 @@ namespace usbguard
   {
     std::string config_line;
     size_t config_line_number = 0;
-    KeyValueParser kvparser(_known_names, "=", /*case_sensitive?*/true, /*validate_keys*/true);
+    KeyValueParser kvparser(_known_names, "=",
+			    /*case_sensitive=*/true,
+			    /*validate_keys=*/!_known_names.empty());
 
     while (std::getline(_stream, config_line)) {
       ++config_line_number;


### PR DESCRIPTION
Addressing:
```
(E) Error: parsed key is not in key set: 'RuleFile'
ERROR: KeyValueParser: Parser: Invalid key
```

Resolves: https://github.com/USBGuard/usbguard/issues/269