### PR TITLE
Rename ListRules parameter 'query' to 'label'

### DIFF
--- a/src/DBus/DBusBridge.cpp
+++ b/src/DBus/DBusBridge.cpp
@@ -104,10 +104,10 @@ namespace usbguard
   void DBusBridge::handlePolicyMethodCall(const std::string& method_name, GVariant* parameters, GDBusMethodInvocation* invocation)
   {
     if (method_name == "listRules") {
-      const char* query_cstr = nullptr;
-      g_variant_get(parameters, "(&s)", &query_cstr);
-      std::string query(query_cstr);
-      auto rules = listRules(query);
+      const char* label_cstr = nullptr;
+      g_variant_get(parameters, "(&s)", &label_cstr);
+      std::string label(label_cstr);
+      auto rules = listRules(label);
 
       if (rules.size() > 0) {
         auto gvbuilder = g_variant_builder_new(G_VARIANT_TYPE_ARRAY);

--- a/src/DBus/DBusInterface.xml
+++ b/src/DBus/DBusInterface.xml
@@ -63,14 +63,14 @@
   <interface name="org.usbguard.Policy1">
     <!--
       listRules:
-       @query: A query, in the rule language syntax, for matching rules.
+       @label: A label for matching rules.
        @ruleset: An array of (rule_id, rule) tuples.
 
       List the current rule set (policy) used by the USBGuard daemon. The
       rules are returned in the same order as they are evaluated.
      -->
     <method name="listRules">
-      <arg name="query" direction="in" type="s"/>
+      <arg name="label" direction="in" type="s"/>
       <arg name="ruleset" direction="out" type="a(us)"/>
     </method>
 

--- a/src/Daemon/Daemon.cpp
+++ b/src/Daemon/Daemon.cpp
@@ -718,13 +718,13 @@ namespace usbguard
     }
   }
 
-  const std::vector<Rule> Daemon::listRules(const std::string& query)
+  const std::vector<Rule> Daemon::listRules(const std::string& label)
   {
-    USBGUARD_LOG(Trace) << "entry: query=" << query;
+    USBGUARD_LOG(Trace) << "entry: label=" << label;
     std::vector<Rule> rules;
 
     for(auto const& rule : _policy.getRuleSet()->getRules()) {
-      if (query.empty() || rule->getLabel() == query) {
+      if (label.empty() || rule->getLabel() == label) {
         rules.push_back(*rule);
       }
     }

--- a/src/Library/IPC/Policy.proto
+++ b/src/Library/IPC/Policy.proto
@@ -4,7 +4,7 @@ import "Message.proto";
 import "Rule.proto";
 
 message listRulesRequest {
-  required string query = 1;
+  required string label = 1;
 }
 
 message listRulesResponse {

--- a/src/Library/IPCClientPrivate.cpp
+++ b/src/Library/IPCClientPrivate.cpp
@@ -397,11 +397,11 @@ namespace usbguard
     auto message_in = qbIPCSendRecvMessage(message_out);
   }
 
-  const std::vector<Rule> IPCClientPrivate::listRules(const std::string& query)
+  const std::vector<Rule> IPCClientPrivate::listRules(const std::string& label)
   {
     IPC::listRules message_out;
     std::vector<Rule> rules;
-    message_out.mutable_request()->set_query(query);
+    message_out.mutable_request()->set_label(label);
     auto message_in = qbIPCSendRecvMessage(message_out);
 
     for (auto rule_message : message_in->response().rules()) {

--- a/src/Library/IPCClientPrivate.hpp
+++ b/src/Library/IPCClientPrivate.hpp
@@ -60,7 +60,7 @@ namespace usbguard
 
     uint32_t appendRule(const std::string& rule_spec, uint32_t parent_id, bool permanent);
     void removeRule(uint32_t id);
-    const std::vector<Rule> listRules(const std::string& query);
+    const std::vector<Rule> listRules(const std::string& label);
 
     uint32_t applyDevicePolicy(uint32_t id, Rule::Target target, bool permanent);
     const std::vector<Rule> listDevices(const std::string& query);

--- a/src/Library/IPCServerPrivate.cpp
+++ b/src/Library/IPCServerPrivate.cpp
@@ -888,11 +888,11 @@ namespace usbguard
      * Get request field values.
      */
     const IPC::listRules* const message_in = static_cast<const IPC::listRules*>(request.get());
-    const std::string query = message_in->request().query();
+    const std::string label = message_in->request().label();
     /*
      * Execute the method.
      */
-    auto rules = _p_instance.listRules(query);
+    auto rules = _p_instance.listRules(label);
     /*
      * Construct the response.
      */

--- a/src/Library/public/usbguard/IPCClient.cpp
+++ b/src/Library/public/usbguard/IPCClient.cpp
@@ -72,9 +72,9 @@ namespace usbguard
     d_pointer->removeRule(id);
   }
 
-  const std::vector<Rule> IPCClient::listRules(const std::string& query)
+  const std::vector<Rule> IPCClient::listRules(const std::string& label)
   {
-    return d_pointer->listRules(query);
+    return d_pointer->listRules(label);
   }
 
   uint32_t IPCClient::applyDevicePolicy(uint32_t id, Rule::Target target, bool permanent)

--- a/src/Library/public/usbguard/IPCClient.hpp
+++ b/src/Library/public/usbguard/IPCClient.hpp
@@ -48,10 +48,10 @@ namespace usbguard
 
     uint32_t appendRule(const std::string& rule_spec, uint32_t parent_id, bool permanent) override;
     void removeRule(uint32_t id) override;
-    const std::vector<Rule> listRules(const std::string& query) override;
+    const std::vector<Rule> listRules(const std::string& label) override;
     const std::vector<Rule> listRules()
     {
-      return listRules("match");
+      return listRules("");
     }
 
     uint32_t applyDevicePolicy(uint32_t id, Rule::Target target, bool permanent) override;


### PR DESCRIPTION
This is a follow up from #293. It includes the global renaming of query to label. It also fixes the default call in IPCClient to match the previous behaviour.