### PR TITLE
Clean up full test suite configuration and documentation

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -255,7 +255,8 @@ libcap_ng_summary="not found"]
 
 PKG_CHECK_MODULES([umockdev], [umockdev-1.0 >= 0.8.0],
 [AC_DEFINE([HAVE_UMOCKDEV], [1], [umockdev API usable])
-umockdev_summary="system-wide; $umockdev_LIBS"],
+umockdev_summary="system-wide; $umockdev_LIBS"
+umockdev_available=yes],
 [AC_MSG_NOTICE([umockdev development files not found! umockdev device manager won't be available])
 umockdev_summary="not found"]
 )
@@ -540,6 +541,12 @@ fi
 AC_ARG_ENABLE([full-test-suite],
               [AS_HELP_STRING([--enable-full-test-suite], [Run the full test suite (default=no)])],
               [full_test_suite=$enableval], [full_test_suite=no])
+
+if test "x$full_test_suite" = xyes; then
+  if test "x$umockdev_available" != xyes; then
+    AC_MSG_ERROR([umockdev is required to run the full test suite.])
+  fi
+fi
 
 # Checks for header files.
 AC_LANG_PUSH([C++])

--- a/src/Tests/UseCase/001_cli_policy.sh
+++ b/src/Tests/UseCase/001_cli_policy.sh
@@ -28,6 +28,9 @@ source "${USBGUARD_TESTLIB_BASH}" || exit 129
 #
 [ -d "/sys/bus/usb/devices" ] || exit 77
 
+# Skip if udevmock-wrapper is not available
+command -v umockdev-wrapper || exit 77
+
 #set -x
 
 # TODO? Move to testlib

--- a/src/Tests/UseCase/001_cli_policy.sh
+++ b/src/Tests/UseCase/001_cli_policy.sh
@@ -18,7 +18,7 @@
 #
 # Authors: Daniel Kopecek <dkopecek@redhat.com>
 #
-# Test whether the binaries are executable as expected (no linker errors, etc.)
+# Test the generation of policy based on umockdev.
 #
 source "${USBGUARD_TESTLIB_BASH}" || exit 129
 

--- a/src/Tests/UseCase/002_cli_devices.sh
+++ b/src/Tests/UseCase/002_cli_devices.sh
@@ -18,7 +18,9 @@
 #
 # Authors: Daniel Kopecek <dkopecek@redhat.com>
 #
-# Test whether the binaries are executable as expected (no linker errors, etc.)
+# Test the authorization of devices using the kernel g_mass_storage and
+# dummy_hcd modules. This test must be run by a user that can elevate
+# their privileges using sudo.
 #
 source "${USBGUARD_TESTLIB_BASH}" || exit 129
 

--- a/src/Tests/UseCase/003_cli_devices_umockdev.sh
+++ b/src/Tests/UseCase/003_cli_devices_umockdev.sh
@@ -17,7 +17,7 @@
 #
 # Authors: Daniel Kopecek <dkopecek@redhat.com>
 #
-# Test whether the binaries are executable as expected (no linker errors, etc.)
+# Test the authorization of devices using umockdev.
 #
 source "${USBGUARD_TESTLIB_BASH}" || exit 129
 

--- a/src/Tests/UseCase/003_cli_devices_umockdev.sh
+++ b/src/Tests/UseCase/003_cli_devices_umockdev.sh
@@ -21,6 +21,9 @@
 #
 source "${USBGUARD_TESTLIB_BASH}" || exit 129
 
+# Skip if udevmock-wrapper is not available
+command -v umockdev-wrapper || exit 77
+
 #set -x
 
 # TODO? Move to testlib

--- a/src/Tests/UseCase/004_daemonize.sh
+++ b/src/Tests/UseCase/004_daemonize.sh
@@ -18,7 +18,7 @@
 #
 # Authors: Jiri Vymazal <jvymazal@redhat.com>
 #
-# Test whether the binaries are executable as expected (no linker errors, etc.)
+# Test the execution of the daemon with an empty configuration.
 #
 source "${USBGUARD_TESTLIB_BASH}" || exit 129
 

--- a/src/Tests/bash-testlib.sh
+++ b/src/Tests/bash-testlib.sh
@@ -19,7 +19,7 @@
 #
 
 # uncomment for debugging
-set -x
+# set -x
 
 COMMAND_QUEUE=()
 COMMAND_JOBID=()
@@ -66,9 +66,11 @@ function schedule()
 #
 function handle_SIGCHLD()
 {
- for j in $(jobs -n); do
-   echo "Job: $j"
- done
+ # uncomment for debugging
+ #for j in $(jobs -n); do
+ #  echo "Job: $j"
+ #done
+ :
 }
 
 function execute()


### PR DESCRIPTION
Includes the silencing of `bash-testlib.sh` jobs (which otherwise makes debugging painful)