### PR TITLE
Re-enable Automake silent rules

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -10,7 +10,7 @@ AC_CONFIG_AUX_DIR([config])
 AM_INIT_AUTOMAKE([subdir-objects foreign tar-pax])
 
 # If automake supports "silent rules", enable them by default
-m4_ifdef([AM_SILENT_RULES], [AM_SILENT_RULES([no])])
+m4_ifdef([AM_SILENT_RULES], [AM_SILENT_RULES([yes])])
 
 #
 # Compiler flags


### PR DESCRIPTION
This was removed in 603186a. It is not clear if this was intentional or not. Re-enable to match the behaviour described in the comment above.