### PR TITLE
Silence 'bind' and 'unbind' uevents

### DIFF
--- a/src/Library/UEventDeviceManager.cpp
+++ b/src/Library/UEventDeviceManager.cpp
@@ -651,6 +651,9 @@ namespace usbguard
           enumeration_notify = true;
         }
       }
+      else if (action == "bind" || action == "unbind") {
+        USBGUARD_LOG(Debug) << action << "=" << sysfs_devpath;
+      }
       else {
         USBGUARD_LOG(Warning) << "Ignoring unknown UEvent action: sysfs_devpath=" << sysfs_devpath
           << " action=" << action;


### PR DESCRIPTION
These are currently reported as unhandled at the warning level. Move to the debug level to limit the noise.