### PR TITLE
Extend the functionality of allow/block/reject commands to work with rules

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -73,7 +73,7 @@ before_install:
 - sudo apt-get install -y asciidoc
 - sudo apt-get install -y umockdev libumockdev-dev
 - sudo gem install coveralls-lcov
-- curl -JLo /tmp/astyle.tgz --remote-header-name 'https://netix.dl.sourceforge.net/project/astyle/astyle/astyle%203.1/astyle_3.1_linux.tar.gz'
+- curl -JLo /tmp/astyle.tgz --remote-header-name 'https://netcologne.dl.sourceforge.net/project/astyle/astyle/astyle%203.1/astyle_3.1_linux.tar.gz'
 install:
 - pushd .
 - cd /tmp

--- a/doc/man/example-allow-device.adoc
+++ b/doc/man/example-allow-device.adoc
@@ -1,0 +1,6 @@
+....
+    # Allow a device by ID(it is the very first number from the list-devices command output)
+    $ sudo usbguard allow-device 10
+    # Allow all the devices named "Dell Wired Multimedia Keyboard"
+    $ sudo usbguard allow-device match name \"Dell Wired Multimedia Keyboard\"
+....

--- a/doc/man/usbguard.1.adoc
+++ b/doc/man/usbguard.1.adoc
@@ -13,11 +13,11 @@ usbguard [OPTIONS] <subcommand> [SUBCOMMAND-OPTIONS] ...
 
 usbguard list-devices
 
-usbguard allow-device 'id'
+usbguard allow-device 'id' | 'rule'
 
-usbguard block-device 'id'
+usbguard block-device 'id' | 'rule'
 
-usbguard reject-device 'id'
+usbguard reject-device 'id' | 'rule'
 
 usbguard list-rules
 
@@ -58,8 +58,8 @@ Available options:
     Show help.
 
 
-=== *allow-device* ['OPTIONS'] 'id'
-Authorize a device identified by the device 'id' to interact with the system.
+=== *allow-device* ['OPTIONS'] <'id' | 'rule'>
+Authorize a device identified by either the device 'id' or a specific 'rule' to interact with the system. A rule might apply to multiple devices. Note that the device 'id' refers to the very first number of the list-devices command output.
 
 Available options:
 
@@ -71,8 +71,8 @@ Available options:
     Show help.
 
 
-=== *block-device* ['OPTIONS'] 'id'
-Deauthorize a device identified by the device 'id'.
+=== *block-device* ['OPTIONS'] <'id' | 'rule'>
+Deauthorize a device identified by either the device 'id' or a specific 'rule'. A rule might apply to multiple devices. Note that the device 'id' refers to the very first number of the list-devices command output.
 
 Available options:
 
@@ -84,8 +84,8 @@ Available options:
     Show help.
 
 
-=== *reject-device* ['OPTIONS'] 'id'
-Deauthorize and remove a device identified by the device 'id'.
+=== *reject-device* ['OPTIONS'] <'id' | 'rule'>
+Deauthorize and remove a device identified by either the device 'id' or a specific 'rule'. A rule might apply to multiple devices. Note that the device 'id' refers to the very first number of the list-devices command output.
 
 Available options:
 
@@ -247,6 +247,10 @@ Available options:
 Generating an initial policy:
 
 include::example-initial-policy.adoc[]
+
+Allow device(s):
+
+include::example-allow-device.adoc[]
 
 
 == SEE ALSO

--- a/src/CLI/usbguard-allow-device.cpp
+++ b/src/CLI/usbguard-allow-device.cpp
@@ -22,6 +22,8 @@
 
 #include "usbguard.hpp"
 #include "usbguard-allow-device.hpp"
+#include "usbguard/RuleParser.hpp"
+#include "Common/Utility.hpp"
 
 #include "usbguard/IPCClient.hpp"
 
@@ -39,7 +41,7 @@ namespace usbguard
 
   static void showHelp(std::ostream& stream)
   {
-    stream << " Usage: " << usbguard_arg0 << " allow-device [OPTIONS] <device-id>" << std::endl;
+    stream << " Usage: " << usbguard_arg0 << " allow-device [OPTIONS] (<device-id> | <rule>)" << std::endl;
     stream << std::endl;
     stream << " Options:" << std::endl;
     stream << "  -p, --permanent  Make the decision permanent. A device specific allow" << std::endl;
@@ -74,15 +76,39 @@ namespace usbguard
 
     argc -= optind;
     argv += optind;
+    usbguard::IPCClient ipc(/*connected=*/true);
 
-    if (argc != 1) {
+    if (argc == 0) {
       showHelp(std::cerr);
       return EXIT_FAILURE;
     }
+    else if (argc == 1) { /* Allow device by ID */
+      id = std::stoul(argv[0]);
+      ipc.applyDevicePolicy(id, Rule::Target::Allow, permanent);
+    }
+    else { /* Allow device by Rule */
+      //Create a string containing each argument(rule)
+      std::vector<std::string> arguments(argv, argv + argc);
+      std::string rule_string = joinElements(arguments.begin(), arguments.end());
+      usbguard::Rule rule;
 
-    id = std::stoul(argv[0]);
-    usbguard::IPCClient ipc(/*connected=*/true);
-    ipc.applyDevicePolicy(id, Rule::Target::Allow, permanent);
+      try {
+        rule = Rule::fromString(rule_string);
+      }
+      catch (const usbguard::RuleParserError& ex) {
+        std::cerr << "ERROR: " << ex.what() << std::endl;
+        showHelp(std::cerr);
+        return EXIT_FAILURE;
+      }
+
+      for (auto rule_device : ipc.listDevices(argv[0])) {
+        if (rule.appliesTo(rule_device)) {
+          id = rule_device.getRuleID();
+          ipc.applyDevicePolicy(id, Rule::Target::Allow, permanent);
+        }
+      }
+    }
+
     return EXIT_SUCCESS;
   }
 } /* namespace usbguard */

--- a/src/CLI/usbguard-block-device.cpp
+++ b/src/CLI/usbguard-block-device.cpp
@@ -22,6 +22,8 @@
 
 #include "usbguard.hpp"
 #include "usbguard-block-device.hpp"
+#include "usbguard/RuleParser.hpp"
+#include "Common/Utility.hpp"
 
 #include "usbguard/IPCClient.hpp"
 
@@ -39,7 +41,7 @@ namespace usbguard
 
   static void showHelp(std::ostream& stream)
   {
-    stream << " Usage: " << usbguard_arg0 << " block-device [OPTIONS] <device-id>" << std::endl;
+    stream << " Usage: " << usbguard_arg0 << " block-device [OPTIONS] (<device-id> | <rule>)" << std::endl;
     stream << std::endl;
     stream << " Options:" << std::endl;
     stream << "  -p, --permanent  Make the decision permanent. A device specific block" << std::endl;
@@ -74,15 +76,39 @@ namespace usbguard
 
     argc -= optind;
     argv += optind;
+    usbguard::IPCClient ipc(/*connected=*/true);
 
-    if (argc != 1) {
+    if (argc == 0) {
       showHelp(std::cerr);
       return EXIT_FAILURE;
     }
+    else if (argc == 1) { /* Block device by ID */
+      id = std::stoul(argv[0]);
+      ipc.applyDevicePolicy(id, Rule::Target::Block, permanent);
+    }
+    else { /* Block device by Rule */
+      //Create a string containing each argument(rule)
+      std::vector<std::string> arguments(argv, argv + argc);
+      std::string rule_string = joinElements(arguments.begin(), arguments.end());
+      usbguard::Rule rule;
 
-    id = std::stoul(argv[0]);
-    usbguard::IPCClient ipc(/*connected=*/true);
-    ipc.applyDevicePolicy(id, Rule::Target::Block, permanent);
+      try {
+        rule = Rule::fromString(rule_string);
+      }
+      catch (const usbguard::RuleParserError& ex) {
+        std::cerr << "ERROR: " << ex.what() << std::endl;
+        showHelp(std::cerr);
+        return EXIT_FAILURE;
+      }
+
+      for (auto rule_device : ipc.listDevices(argv[0])) {
+        if (rule.appliesTo(rule_device)) {
+          id = rule_device.getRuleID();
+          ipc.applyDevicePolicy(id, Rule::Target::Block, permanent);
+        }
+      }
+    }
+
     return EXIT_SUCCESS;
   }
 } /* namespace usbguard */

--- a/src/Common/Utility.hpp
+++ b/src/Common/Utility.hpp
@@ -294,6 +294,24 @@ namespace usbguard
     int _fd{-1};
   };
 
+
+  template<typename T>
+  std::string joinElements(T begin, T end, const std::string& separator = " ")
+  {
+    std::ostringstream ss;
+
+    if (begin != end) {
+      ss << *(begin++);
+    }
+
+    while (begin != end) {
+      ss << separator << *(begin++);
+    }
+
+    return ss.str();
+  }
+
+
 } /* namespace usbguard */
 
 /* vim: set ts=2 sw=2 et */


### PR DESCRIPTION
These commands are now able to work with either a **device id** or a specific **device rule**.