### PR TITLE
Add match-all keyword

### DIFF
--- a/doc/man/usbguard-rules.conf.5.adoc
+++ b/doc/man/usbguard-rules.conf.5.adoc
@@ -93,6 +93,9 @@ where the optional 'operator' is one of:
 *equals-ordered*::
     The device attribute set must contain exactly the same set of values in the same order for the rule to match.
 
+*match-all*::
+   The device attribute set must be a subset of the specified values for the rule to match.
+
 If the operator is not specified it is set to *equals*.
 
 [.underline]#List of attributes:#

--- a/scripts/rule-generator.sh
+++ b/scripts/rule-generator.sh
@@ -23,7 +23,7 @@ function generate_target {
   echo -n ${TARGET[$RANDOM % 3]}
 }
 
-OPERATORS=(equals one-of none-of all-of equals-ordered)
+OPERATORS=(equals one-of none-of all-of equals-ordered match-all)
 
 function generate_hex {
   size=$1

--- a/src/Library/RuleParser/Grammar.hpp
+++ b/src/Library/RuleParser/Grammar.hpp
@@ -15,6 +15,7 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 //
 // Authors: Daniel Kopecek <dkopecek@redhat.com>
+//          Marek Tamaskovic <mtamasko@redhat.com>
 //
 #pragma once
 #ifdef HAVE_BUILD_CONFIG_H
@@ -55,12 +56,13 @@ namespace usbguard
     struct str_none_of : TAOCPP_PEGTL_STRING("none-of") {};
     struct str_equals : TAOCPP_PEGTL_STRING("equals") {};
     struct str_equals_ordered : TAOCPP_PEGTL_STRING("equals-ordered") {};
+    struct str_match_all: TAOCPP_PEGTL_STRING("match-all") {};
 
     /*
      * Generic rule attribute
      */
     struct multiset_operator
-      : sor<str_all_of, str_one_of, str_none_of, str_equals_ordered, str_equals> {};
+      : sor<str_all_of, str_one_of, str_none_of, str_equals_ordered, str_equals, str_match_all> {};
 
     template<class attribute_value_rule>
     struct attribute_value_multiset

--- a/src/Library/RulePrivate.cpp
+++ b/src/Library/RulePrivate.cpp
@@ -15,6 +15,7 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 //
 // Authors: Daniel Kopecek <dkopecek@redhat.com>
+//          Marek Tamaskovic <mtamasko@redhat.com>
 //
 #ifdef HAVE_BUILD_CONFIG_H
   #include <build-config.h>
@@ -140,6 +141,7 @@ namespace usbguard
     case Rule::SetOperator::AllOf:
     case Rule::SetOperator::Equals:
     case Rule::SetOperator::EqualsOrdered:
+    case Rule::SetOperator::MatchAll:
       meets_conditions = \
         (conditionsState() == ((((uint64_t)1) << _conditions.count()) - 1));
       break;

--- a/src/Library/public/usbguard/Predicates.hpp
+++ b/src/Library/public/usbguard/Predicates.hpp
@@ -15,6 +15,7 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 //
 // Authors: Daniel Kopecek <dkopecek@redhat.com>
+//          Marek Tamaskovic <mtamasko@redhat.com>
 //
 #pragma once
 
@@ -34,6 +35,15 @@ namespace usbguard
     {
       USBGUARD_LOG(Trace) << "generic isSubsetOf";
       return source == target;
+    }
+
+    template<typename T>
+    bool isSupersetOf(const T& source, const T& target)
+    {
+      USBGUARD_LOG(Error) << "Not implemented";
+      (void) source;
+      (void) target;
+      return true;
     }
   }
 } /* namespace usbguard */

--- a/src/Library/public/usbguard/Rule.cpp
+++ b/src/Library/public/usbguard/Rule.cpp
@@ -15,6 +15,7 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 //
 // Authors: Daniel Kopecek <dkopecek@redhat.com>
+//          Marek Tamaskovic <mtamasko@redhat.com>
 //
 #ifdef HAVE_BUILD_CONFIG_H
   #include <build-config.h>
@@ -367,7 +368,8 @@ namespace usbguard
     { "none-of", Rule::SetOperator::NoneOf },
     { "equals", Rule::SetOperator::Equals },
     { "equals-ordered", Rule::SetOperator::EqualsOrdered },
-    { "match", Rule::SetOperator::Match }
+    { "match", Rule::SetOperator::Match },
+    { "match-all", Rule::SetOperator::MatchAll}
   };
 
   const std::string Rule::setOperatorToString(const Rule::SetOperator& op)

--- a/src/Library/public/usbguard/USB.cpp
+++ b/src/Library/public/usbguard/USB.cpp
@@ -15,6 +15,7 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 //
 // Authors: Daniel Kopecek <dkopecek@redhat.com>
+//          Marek Tamaskovic <mtamasko@redhat.com>
 //
 #ifdef HAVE_BUILD_CONFIG_H
   #include <build-config.h>
@@ -111,6 +112,15 @@ namespace usbguard
   {
     USBGUARD_LOG(Trace) << "source=" << source.toString() << " target=" << target.toString();
     const bool result = source.isSubsetOf(target);
+    USBGUARD_LOG(Trace) << "result=" << result;
+    return result;
+  }
+
+  template<>
+  bool Predicates::isSupersetOf(const USBDeviceID& source, const USBDeviceID& target)
+  {
+    USBGUARD_LOG(Trace) << "source=" << source.toString() << " target=" << target.toString();
+    const bool result = target.isSubsetOf(source);
     USBGUARD_LOG(Trace) << "result=" << result;
     return result;
   }
@@ -220,6 +230,12 @@ namespace usbguard
 
   template<>
   bool Predicates::isSubsetOf(const USBInterfaceType& source, const USBInterfaceType& target)
+  {
+    return source.appliesTo(target);
+  }
+
+  template<>
+  bool Predicates::isSupersetOf(const USBInterfaceType& source, const USBInterfaceType& target)
   {
     return source.appliesTo(target);
   }

--- a/src/Library/public/usbguard/USB.hpp
+++ b/src/Library/public/usbguard/USB.hpp
@@ -15,6 +15,7 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 //
 // Authors: Daniel Kopecek <dkopecek@redhat.com>
+//          Marek Tamaskovic <mtamasko@redhat.com>
 //
 #pragma once
 
@@ -170,6 +171,8 @@ namespace usbguard
   {
     template<>
     bool isSubsetOf(const USBDeviceID& source, const USBDeviceID& target);
+    template<>
+    bool isSupersetOf(const USBDeviceID& source, const USBDeviceID& target);
   }
 
   class DLL_PUBLIC USBInterfaceType
@@ -203,6 +206,8 @@ namespace usbguard
   {
     template<>
     bool isSubsetOf(const USBInterfaceType& source, const USBInterfaceType& target);
+    template<>
+    bool isSupersetOf(const USBInterfaceType& source, const USBInterfaceType& target);
   }
 
   class USBDescriptorParser;


### PR DESCRIPTION
Keyword match-all extends functionality of the current grammar.
Example:
```allow id *:* with-interface all-of { 03:*:* 09:*:* }```
this will check if the interfaces from set `{ 03:*:* 09:*:* }` are present in the device in other words if the set `{ 03:*:* 09:*:* }` is subset of the device interfaces.

In the other hand rule like this: ```allow id *:* with-interface match-all { 03:*:* 09:*:* }``` will check if all of the interfaces in the device are subset of the set { 03:*:* 09:*:* }.

The difference is that in the case of the `match-all` keyword we can have device like keyboard `{03:00:01}` and match it against that one rule (```allow id *:* with-interface match-all { 03:*:* 09:*:* }```). 