### PR TITLE
.gitmodules: Drop unused usbmon

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,6 @@
 [submodule "src/ThirdParty/Catch"]
 	path = src/ThirdParty/Catch
 	url = https://github.com/philsquared/Catch
-[submodule "src/ThirdParty/usbmon"]
-	path = src/ThirdParty/usbmon
-	url = https://github.com/radosroka/usbmon
 [submodule "src/ThirdParty/PEGTL"]
 	path = src/ThirdParty/PEGTL
 	url = https://github.com/ColinH/PEGTL


### PR DESCRIPTION
Hi!

It came to my attention that Git submodule `usbmon` does not seem to be used by anything, if I can trust `git grep` about it. Can it be dropped?

Best, Sebastian

PS: I think usbguard is pretty awesome and it's running on all my laptops now. I [have packaged version 0.7.6 for Gentoo](https://github.com/gentoo/gentoo/commit/418a356ac55fb3ac19acd269ec593ce436a0f456) a few days ago. Thanks for making this thing and sharing it as software libre!