### PR TITLE
Prevent data corruption on stack via DBus during appendRule

### DIFF
--- a/src/DBus/DBusBridge.cpp
+++ b/src/DBus/DBusBridge.cpp
@@ -138,7 +138,7 @@ namespace usbguard
     if (method_name == "appendRule") {
       const char* rule_spec_cstr = nullptr;
       uint32_t parent_id = 0;
-      bool temporary = false;
+      gboolean temporary = false;
       g_variant_get(parameters, "(&sub)", &rule_spec_cstr, &parent_id, &temporary);
       std::string rule_spec(rule_spec_cstr);
       const uint32_t rule_id = appendRule(rule_spec, parent_id, !temporary);

--- a/src/DBus/DBusInterface.xml
+++ b/src/DBus/DBusInterface.xml
@@ -207,6 +207,9 @@
        @target_new: Current authorization target in numerical form.
        @device_rule: Device specific rule.
        @rule_id: A rule id of the matched rule. Otherwise a reserved rule id value is used.
+                 Reserved values are:
+                     4294967294 (UINT32_MAX - 1) for an implicit rule, e.g. 
+                     ImplicitPolicyTarget or InsertedDevicePolicy.
        @attributes: A dictionary of device attributes and their values.
 
       Notify about a change of a USB device authorization target.

--- a/src/DBus/DBusInterface.xml
+++ b/src/DBus/DBusInterface.xml
@@ -83,7 +83,9 @@
 
       Append a new rule to the current policy. Using the parent_id
       parameter, the rule can be inserted anywhere in the policy,
-      not only at the end. When the rule is successfully appended,
+      not only at the end. 4294967293 (UINT32_MAX-2) is the last possible
+      ID and thus, when using this as parent id, the rule is effectively
+      appended to the list of rules. When the rule is successfully appended,
       the id assigned to the new rule is returned.
      -->
     <method name="appendRule">


### PR DESCRIPTION
I have tried to append a rule via DBus. From reading the code it seems that `UINT32_MAX - 2` is "LastID".

https://github.com/USBGuard/usbguard/blob/db5553d12ed3db63019fa7b640b32ab93554d035/src/Library/public/usbguard/Rule.cpp#L37

and then it's used here to append to the list of rules:

https://github.com/USBGuard/usbguard/blob/db5553d12ed3db63019fa7b640b32ab93554d035/src/Library/public/usbguard/RuleSet.cpp#L97

My naive thinking was that 4294967295 (`UINT32_MAX`) - 2 = 4294967293 would be a good candidate. But it fails:
```
$ dbus-send --system --print-reply --dest=org.usbguard1 /org/usbguard1/Policy org.usbguard.Policy1.appendRule string:"allow" uint32:4294967293 boolean:true
Error org.freedesktop.DBus.Error.Failed: Rule set append: rule: Invalid parent ID
$
```

Using the command line works, though:
```
$ ./usbguard append-rule --after 4294967293 allow
19
$ 
```

It seems values up to 16777215 (i.e. `1<<24` or 24 bit), work fine.

While debugging I noticed how the `parent_id` was written twice. Once when extracting the int from the GVariant and then again when extracting the Boolean. Turns out, a C++ Boolean is one byte large while a gboolean, as used by GLib, is four bytes. That's why three bytes of the integer get overwritten when extracting the GVariant.

https://github.com/USBGuard/usbguard/blob/50c99211d512b963a8bcf271e316b65b967ab585/src/DBus/DBusBridge.cpp#L141-L142

is the problem. It uses a small C++ Boolean.
The only other case where a Boolean is extracted out of a GVariant is here:

https://github.com/USBGuard/usbguard/blob/50c99211d512b963a8bcf271e316b65b967ab585/src/DBus/DBusBridge.cpp#L200-L201

There, the gboolean is used correctly.

CCing @tweksteen as the author of the offending line.

As an aside: Using ASan didn't yield interesting results :-/ I thought it was well able to detect overflowing stack objects. Maybe it has a minimum object size to protect...


Anyway, while I concerned myself with the innards of USBGuard, I also patched the documentation. Because not entirely unrelated, I throw these commits into the mix. I'll happily remove them from this PR if required, though.