### PR TITLE
Add with-connect-type to dbus signals

### DIFF
--- a/src/DBus/DBusBridge.cpp
+++ b/src/DBus/DBusBridge.cpp
@@ -337,6 +337,11 @@ namespace usbguard
     g_variant_builder_add(builder, "{ss}",
       "with-interface",
       with_interface_string.c_str());
+
+    g_variant_builder_add(builder, "{ss}",
+      "with-connect-type",
+      device_rule.getWithConnectType().c_str());
+
     return builder;
   }
 } /* namespace usbguard */

--- a/src/DBus/DBusInterface.xml
+++ b/src/DBus/DBusInterface.xml
@@ -184,6 +184,7 @@
         - hash
         - parent-hash
         - with-interface
+        - with-connect-type (either "hardwired", "hotplug", or the empty string for unknown)
 
       The USB interface types are represented as strings of the form AA:BB:CC, where AA,
       BB, and CC are hexadecimal numbers representing the class, subclass and protocol
@@ -217,6 +218,7 @@
         - hash
         - parent-hash
         - with-interface
+        - with-connect-type (either "hardwired", "hotplug", or the empty string for unknown)
 
      -->
     <signal name="DevicePolicyChanged">


### PR DESCRIPTION
This also adds with-connect-type to the documentation.

https://github.com/USBGuard/usbguard/issues/354
https://github.com/USBGuard/usbguard/issues/340

CCing @gwinkenbach as the author of with-connect-type in https://github.com/USBGuard/usbguard/pull/274