### PR TITLE
Add configure flags for optional libraries.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -232,35 +232,67 @@ AC_SUBST([crypto_LIBS])
 #
 # Check for optional libraries
 #
-PKG_CHECK_MODULES([audit], [audit >= 2.7.7],
-[AC_DEFINE([HAVE_LINUX_AUDIT], [1], [Linux Audit API available])
-AC_CHECK_DECLS([audit_encode_nv_string], [], [], [[#include<libaudit.h>]])
-libaudit_summary="system-wide; $audit_LIBS"],
-[AC_MSG_NOTICE([libaudit development files not found! Linux Audit support wille be turned OFF])
-libaudit_summary="not found"]
-)
+AC_ARG_ENABLE([audit],
+              [AS_HELP_STRING([--enable-audit], [Enables Linux Audit support if available (default=yes)])],
+              [use_audit=$enableval], [use_audit=yes])
 
-PKG_CHECK_MODULES([seccomp], [libseccomp >= 2.0.0],
-[AC_DEFINE([HAVE_SECCOMP], [1], [seccomp API usable])
-libseccomp_summary="system-wide; $seccomp_LIBS"],
-[AC_MSG_NOTICE([libseccomp development files not found! Seccomp support will be turned OFF])
-libseccomp_summary="not found"]
-)
+if test "x$use_audit" = xyes; then
+  PKG_CHECK_MODULES([audit], [audit >= 2.7.7],
+  [AC_DEFINE([HAVE_LINUX_AUDIT], [1], [Linux Audit API available])
+  AC_CHECK_DECLS([audit_encode_nv_string], [], [], [[#include<libaudit.h>]])
+  libaudit_summary="system-wide; $audit_LIBS"],
+  [AC_MSG_NOTICE([libaudit development files not found! Linux Audit support wille be turned OFF])
+  libaudit_summary="not found"]
+  )
+else
+  libaudit_summary="not enabled"
+fi
 
-PKG_CHECK_MODULES([libcapng], [libcap-ng >= 0.7.0],
-[AC_DEFINE([HAVE_LIBCAPNG], [1], [cap-ng API usable])
-libcap_ng_summary="system-wide; $libcapng_LIBS"],
-[AC_MSG_NOTICE([libcap-ng development files not found! Support for POSIX 1003.1e capabilities will be turned OFF])
-libcap_ng_summary="not found"]
-)
+AC_ARG_ENABLE([seccomp],
+              [AS_HELP_STRING([--enable-seccomp], [Enables Seccomp support if available (default=yes)])],
+              [use_seccomp=$enableval], [use_seccomp=yes])
 
-PKG_CHECK_MODULES([umockdev], [umockdev-1.0 >= 0.8.0],
-[AC_DEFINE([HAVE_UMOCKDEV], [1], [umockdev API usable])
-umockdev_summary="system-wide; $umockdev_LIBS"
-umockdev_available=yes],
-[AC_MSG_NOTICE([umockdev development files not found! umockdev device manager won't be available])
-umockdev_summary="not found"]
-)
+if test "x$use_seccomp" = xyes; then
+  PKG_CHECK_MODULES([seccomp], [libseccomp >= 2.0.0],
+  [AC_DEFINE([HAVE_SECCOMP], [1], [seccomp API usable])
+  libseccomp_summary="system-wide; $seccomp_LIBS"],
+  [AC_MSG_NOTICE([libseccomp development files not found! Seccomp support will be turned OFF])
+  libseccomp_summary="not found"]
+  )
+else
+  libseccomp_summary="not enabled"
+fi
+
+AC_ARG_ENABLE([libcapng],
+              [AS_HELP_STRING([--enable-libcapng], [Enables POSIX 1003.1e capability support if available (default=yes)])],
+              [use_libcapng=$enableval], [use_libcapng=yes])
+
+if test "x$use_libcapng" = xyes; then
+  PKG_CHECK_MODULES([libcapng], [libcap-ng >= 0.7.0],
+  [AC_DEFINE([HAVE_LIBCAPNG], [1], [cap-ng API usable])
+  libcap_ng_summary="system-wide; $libcapng_LIBS"],
+  [AC_MSG_NOTICE([libcap-ng development files not found! Support for POSIX 1003.1e capabilities will be turned OFF])
+  libcap_ng_summary="not found"]
+  )
+else
+  libcap_ng_summary="not enabled"
+fi
+
+AC_ARG_ENABLE([umockdev],
+              [AS_HELP_STRING([--enable-umockdev], [Enables Seccomp support if available (default=yes)])],
+              [use_umockdev=$enableval], [use_umockdev=yes])
+
+if test "x$use_umockdev" = xyes; then
+  PKG_CHECK_MODULES([umockdev], [umockdev-1.0 >= 0.8.0],
+  [AC_DEFINE([HAVE_UMOCKDEV], [1], [umockdev API usable])
+  umockdev_summary="system-wide; $umockdev_LIBS"
+  umockdev_available=yes],
+  [AC_MSG_NOTICE([umockdev development files not found! umockdev device manager won't be available])
+  umockdev_summary="not found"]
+  )
+else
+  umockdev_summary="not enabled"
+fi
 
 PKG_CHECK_MODULES([protobuf], [protobuf >= 2.5.0],
 [protobuf_summary="system-wide; $protobuf_CFLAGS $protobuf_LIBS"],


### PR DESCRIPTION
This enables distributions to force disable features based on optional dependencies to avoid unexpected behavior when extra headers are present.