### PR TITLE
Drop unused PIDFile statement from service file

### DIFF
--- a/usbguard.service.in
+++ b/usbguard.service.in
@@ -19,7 +19,6 @@ ProtectControlGroups=yes
 ProtectHome=yes
 ProtectKernelModules=yes
 ProtectSystem=yes
-PIDFile=/run/usbguard.pid
 ReadOnlyPaths=-/
 ReadWritePaths=-/dev/shm -%localstatedir%/log/usbguard -/tmp -%sysconfdir%/usbguard/
 Restart=on-failure


### PR DESCRIPTION
The service file does not start usbguard in daemon mode so the PIDFile is never creatd. Therefore the PIDFile statement in the service file is not needed and might lead to confusion.