### PR TITLE
Handle RuleSet when RulePath is specified but RuleDirPath not.

### DIFF
--- a/src/Daemon/RuleSetFactory.cpp
+++ b/src/Daemon/RuleSetFactory.cpp
@@ -63,7 +63,7 @@ namespace usbguard
 
     switch (type) {
     case NSHandler::SourceType::LOCAL:
-      if (ns.getRulesPath() != "") {
+      if (!ns.getRulesPath().empty()) {
         ruleSet.emplace_back(new FileRuleSet(interface_ptr, ns.getRulesPath()));
       }
 
@@ -74,7 +74,7 @@ namespace usbguard
           ruleSet.push_back(rs);
         }
       }
-      else {
+      else if (ns.getRulesPath().empty()){
         USBGUARD_LOG(Warning) << "RuleFile not set; Modification of the permanent policy won't be possible.";
         ruleSet = generateDefaultRuleSet();
       }

--- a/src/Library/public/usbguard/Policy.cpp
+++ b/src/Library/public/usbguard/Policy.cpp
@@ -69,7 +69,7 @@ namespace usbguard
       }
 
       auto rules = ruleset->getRules();
-      return ruleset->appendRule(*rule, rules.back()->getRuleID());
+      return ruleset->appendRule(*rule);
     }
 
     for (auto ruleset : _rulesets_ptr) {


### PR DESCRIPTION
This eliminates src/Tests/UseCase/001_cli_policy.sh test failure.