### PR TITLE
Extend RuleFolder description with naming conventions

### DIFF
--- a/doc/man/usbguard-daemon.conf.5.adoc
+++ b/doc/man/usbguard-daemon.conf.5.adoc
@@ -24,7 +24,9 @@ It may be overridden using the *-c* command-line option, see *usbguard-daemon*(8
     it and to write new rules received via the IPC interface. Usually, we set
     the option to `/etc/usbguard/rules.d/`. The USBGuard daemon is supposed to
     behave like any other standard Linux daemon therefore it loads rule files in
-    alpha-numeric order.
+    alpha-numeric order. File names inside `RuleFolder` directory should start
+    with a two-digit number prefix indicating the position, in which the rules
+    are scanned by the daemon.
 
 *ImplicitPolicyTarget*='target'::
     How to treat USB devices that don't match any rule in the policy. Target

--- a/usbguard-daemon.conf.in
+++ b/usbguard-daemon.conf.in
@@ -14,7 +14,13 @@ RuleFile=%sysconfdir%/usbguard/rules.conf
 #
 # The USBGuard daemon will use this folder to load the policy
 # rule set from it and to write new rules received via the
-# IPC interface.
+# IPC interface. Usually, we set the option to
+# /etc/usbguard/rules.d/. The USBGuard daemon is supposed to
+# behave like any other standard Linux daemon therefore it
+# loads rule files in alpha-numeric order. File names inside
+# RuleFolder directory should start with a two-digit number
+# prefix indicating the position, in which the rules are
+# scanned by the daemon.
 #
 # RuleFolder=/path/to/rulesfolder/
 #


### PR DESCRIPTION
File names inside RuleFolder should start with an at least two-digit number prefix, e.g. 00_rule.conf, 01_another_rule.conf. 

It would force the **usbguard-daemon** to scan those rules in the requested order. 