### PR TITLE
Always throw the DevicePolicyChanged signal

### DIFF
--- a/src/DBus/DBusInterface.xml
+++ b/src/DBus/DBusInterface.xml
@@ -213,7 +213,11 @@
                      ImplicitPolicyTarget or InsertedDevicePolicy.
        @attributes: A dictionary of device attributes and their values.
 
-      Notify about a change of a USB device authorization target.
+      This signal fires whenever a device is present (i.e. during startup
+      of the daemon), inserted (i.e. plugged in), or updated (i.e. when a rule
+      has been updated).
+
+      This signal is poorly named. It should probably be called "RuleApplied".
 
       The device attribute dictionary contains the following attributes:
         - id (the USB device ID in the form VID:PID)

--- a/src/Daemon/Daemon.cpp
+++ b/src/Daemon/Daemon.cpp
@@ -854,16 +854,16 @@ namespace usbguard
       else {
         USBGUARD_LOG(Debug) << "Implicit rule matched";
       }
-
-      std::shared_ptr<const Rule> device_rule = \
-        device_post->getDeviceRule(/*with_port=*/true,
-          /*with_parent_hash=*/true);
-      DevicePolicyChanged(device->getID(),
-        target_old,
-        device_post->getTarget(),
-        device_rule->toString(),
-        matched_rule->getRuleID());
     }
+
+    std::shared_ptr<const Rule> device_rule = \
+      device_post->getDeviceRule(/*with_port=*/true,
+        /*with_parent_hash=*/true);
+    DevicePolicyChanged(device->getID(),
+      target_old,
+      device_post->getTarget(),
+      device_rule->toString(),
+      matched_rule->getRuleID());
 
     matched_rule->updateMetaDataCounters(/*applied=*/true);
     audit_event.success();


### PR DESCRIPTION
The motivation is to have a simple "this is what happens with the device" signal, e.g. whether a device is accepted or rejected. This makes writing front-ends easier. I dare to say that this is the precondition to make it possible at all. As mentioned in https://github.com/USBGuard/usbguard/issues/353 it is difficult, at best, to write something useful with the current behaviour of the signal, which is a bit hard to explain.
Right now, the signal is being thrown when a device is present, inserted, or updated, except when a rule has matched that has changed whatever the implicit rule said it would do.  If I want to know whether an inserted device is actually enabled, I need to listen to the PresenceChanged signal and then wait for the PolicyChanged signal. Except that it doesn't necessarily come which makes it hard to follow.

I have tried to find consumers of this signal and I have [found three](https://codesearch.debian.net/search?q=DevicePolicyChanged&literal=1). Chrome OS, GNOME, and [py3status](https://sources.debian.org/src/py3status/3.22-1/py3status/modules/usbguard.py/?hl=98#L98). I don't know whether and how Chrome OS will suffer from this change, but it could be that it breaks something on their end. It will certainly help GNOME. And after having looked at what py3status wants to achieve, my guess is that it will benefit from this change, too. From what I can see, they don't want the current behaviour but, much like GNOME, something that tells them what happens to an inserted device.

I appreciate that changing the behaviour of a signal is frowned upon. But I question the usefulness of the current signal and I doubt that Chrome OS has a usecase that requires this signal (but again: I haven't checked).
Introducing a new signal is certainly possible and would probably be the cleanest approach. But I know little about USBGuard and just moving the emission of the signal out of the guard is a really simple change in the code. A new signal seems to involve a lot of boilerplate for the multi-layer IPC abstraction. No fun.

Another option is to rename the signal, i.e. to remove the existing signal and introduce a new one. This *should* be fairly easy with `sed`. But it will at least actively break the existing consumers. And it might break more things that we don't know of yet. Not that this is a good reason to not do the correct thing, but I thought I'd come up with the easiest solution for me and listen to what you think.
