### PR TITLE
doc: include defaults in the description

### DIFF
--- a/doc/man/usbguard-daemon.conf.5.adoc
+++ b/doc/man/usbguard-daemon.conf.5.adoc
@@ -18,6 +18,7 @@ It may be overridden using the *-c* command-line option, see *usbguard-daemon*(8
 *RuleFile*='path'::
     The USBGuard daemon will use this file to load the policy rule set from it
     and to write new rules received via the IPC interface.
+    Default: %sysconfdir%/usbguard/rules.conf
 
 *RuleFolder*='path'::
     The USBGuard daemon will use this folder to load the policy rule set from
@@ -32,20 +33,24 @@ It may be overridden using the *-c* command-line option, see *usbguard-daemon*(8
     How to treat USB devices that don't match any rule in the policy. Target
     should be one of `allow`, `block` or `reject` (logically remove the device
     node from the system).
+    Default: block
 
 *PresentDevicePolicy*='policy'::
     How to treat USB devices that are already connected when the daemon starts.
     Policy should be one of `allow`, `block`, `reject`, `keep` (keep whatever
     state the device is currently in) or `apply-policy` (evaluate the rule set
     for every present device).
+    Default: apply-policy
 
 *PresentControllerPolicy*='policy'::
     How to treat USB *controller* devices that are already connected when the
     daemon starts. One of `allow`, `block`, `reject`, `keep` or `apply-policy`.
+    Default: keep
 
 *InsertedDevicePolicy*='policy'::
     How to treat USB devices that are already connected _after_ the daemon
     starts. One of `block`, `reject`, `apply-policy`.
+    Default: apply-policy
 
 *AuthorizedDefault*='authorizedDefault'::
     The USBGuard daemon modifies some of the default authorization state
@@ -55,12 +60,14 @@ It may be overridden using the *-c* command-line option, see *usbguard-daemon*(8
     devices start out authorized, wireless do not), `none` (every new device
     starts out deauthorized), `all` (every new device starts out authorized) or
     `internal` (internal devices start out authorized, external do not).
+    Default: none
 
 *RestoreControllerDeviceState*='boolean'::
     The USBGuard daemon modifies some attributes of controller devices like the
     default authorization state of new child device instances. Using this
     setting, you can control whether the daemon will try to restore the
     attribute values to the state before modification on shutdown.
+    Default: false
 
 *DeviceManagerBackend*='backend'::
     Which device manager backend implementation to use. Backend should be one
@@ -69,10 +76,12 @@ It may be overridden using the *-c* command-line option, see *usbguard-daemon*(8
     and an uevent socket for receiving USB device related events. UMockDev
     based device manager is capable of simulating devices based on
     umockdev-record files.
+    Default: uevent
 
 *IPCAllowedUsers*='username' ['username' ...]::
     A space delimited list of usernames that the daemon will accept IPC
     connections from.
+    Default: root
 
 *IPCAllowedGroups*='groupname' ['groupname' ...]::
     A space delimited list of groupnames that the daemon will accept IPC
@@ -85,18 +94,22 @@ It may be overridden using the *-c* command-line option, see *usbguard-daemon*(8
 
 *DeviceRulesWithPort*='boolean'::
     Generate device specific rules including the "via-port" attribute.
+    Default: false
 
 *AuditBackend*='backend'::
     USBGuard audit events log backend. The 'backend' value should be one of
     `FileAudit` or `LinuxAudit`.
+    Default: FileAudit
 
 *AuditFilePath*='filepath'::
     USBGuard audit events log file path. Required if AuditBackend is set to
     `FileAudit`.
+    Default: %localstatedir%/log/usbguard/usbguard-audit.log
 
 *HidePII*='boolean'::
     Hides personally identifiable information such as device serial numbers and
     hashes of descriptors (which include the serial number) from audit entries.
+    Default: false
 
 
 == SECURITY CONSIDERATIONS


### PR DESCRIPTION
The intention of this change is to make it easier to understand what
USBGuard does by looking at the docs, in particular the Web site.
The defaults have been taken from usbguard-daemon.conf.in. I haven't
noticed any automatic way to generated the (part) of the documentation
from that file, although it might be clever to do in order to lower the
redundancy.

Note that I haven't built the docs, mainly, because I don't know how to, and thus I haven't checked whether it looks nice enough and whether it actually lands in the generated Web sites served at https://usbguard.github.io/documentation/configuration.html#options