### PR TITLE
Remove 'wired' option for authorize_ default.

### DIFF
--- a/doc/man/usbguard-daemon.conf.5.adoc
+++ b/doc/man/usbguard-daemon.conf.5.adoc
@@ -56,8 +56,7 @@ It may be overridden using the *-c* command-line option, see *usbguard-daemon*(8
     The USBGuard daemon modifies some of the default authorization state
     attributes of controller devices. This setting, enables you to define what
     value the default authorization is set to. Authorized default should be one
-    of `keep` (do not change authorization state), `wired` (new wired USB
-    devices start out authorized, wireless do not), `none` (every new device
+    of `keep` (do not change authorization state), `none` (every new device
     starts out deauthorized), `all` (every new device starts out authorized) or
     `internal` (internal devices start out authorized, external do not).
     Default: none

--- a/src/Library/public/usbguard/DeviceManager.cpp
+++ b/src/Library/public/usbguard/DeviceManager.cpp
@@ -71,7 +71,6 @@ namespace usbguard
 
   static const std::vector<std::pair<std::string, DeviceManager::AuthorizedDefaultType>> authorized_default_type_strings = {
     { "keep", DeviceManager::AuthorizedDefaultType::Keep },
-    { "wired", DeviceManager::AuthorizedDefaultType::Wired },
     { "none", DeviceManager::AuthorizedDefaultType::None },
     { "all", DeviceManager::AuthorizedDefaultType::All },
     { "internal", DeviceManager::AuthorizedDefaultType::Internal }

--- a/src/Library/public/usbguard/DeviceManager.hpp
+++ b/src/Library/public/usbguard/DeviceManager.hpp
@@ -60,8 +60,6 @@ namespace usbguard
      */
     enum class AuthorizedDefaultType {
       Keep = -128, /**< Do not change the authorization state. */
-      Wired = -1, /**< New wired USB devices start out authorized,
-                    wireless USB devices do not. */
       None = 0, /**< Every new device starts out deauthorized. */
       All = 1, /**< Every new device starts out authorized. */
       Internal = 2, /**< Internal devices start out authorized,

--- a/usbguard-daemon.conf.in
+++ b/usbguard-daemon.conf.in
@@ -91,8 +91,6 @@ InsertedDevicePolicy=apply-policy
 # default authorization is set to.
 #
 # * keep         - do not change the authorization state
-# * wired        - new wired USB devices start out authorized, wireless USB
-#                  devices do not
 # * none         - every new device starts out deauthorized
 # * all          - every new device starts out authorized
 # * internal     - internal devices start out authorized, external devices start


### PR DESCRIPTION
- this option was blindly implemented and it was never supposed to work
- kernel's authorized_default for controllers cannot handle -1
- we need to remove the option from the usbguard completelly

Signed-off-by: Radovan Sroka <rsroka@redhat.com>