### PR TITLE
Fix thread copy assignment bug

### DIFF
--- a/src/Common/Thread.hpp
+++ b/src/Common/Thread.hpp
@@ -45,7 +45,7 @@ namespace usbguard
       _method_class_ptr = thread._method_class_ptr;
       _method = thread._method;
       std::swap(_thread, thread._thread);
-      _stop_request = thread._stop_request;
+      _stop_request = thread._stop_request.load();
     }
 
     Thread& operator=(Thread& thread)
@@ -53,7 +53,7 @@ namespace usbguard
       _method_class_ptr = thread._method_class_ptr;
       _method = thread._method;
       std::swap(_thread, thread._thread);
-      _stop_request = thread._stop_request;
+      _stop_request = thread._stop_request.load();
       return *this;
     }
 


### PR DESCRIPTION
Common/Thread.hpp is using copy assignment operator on std::atomic_bool which is deleted. Compilation error never arose because thread copy assignment constructor and operator were unused.