### PR TITLE
Always check if device exists before changing device policy

### DIFF
--- a/src/CLI/usbguard-allow-device.cpp
+++ b/src/CLI/usbguard-allow-device.cpp
@@ -104,7 +104,10 @@ namespace usbguard
       for (auto rule_device : ipc.listDevices(argv[0])) {
         if (rule.appliesTo(rule_device)) {
           id = rule_device.getRuleID();
-          ipc.applyDevicePolicy(id, Rule::Target::Allow, permanent);
+          try {
+            ipc.applyDevicePolicy(id, Rule::Target::Allow, permanent);
+          }
+          catch (const usbguard::Exception& ex) {}
         }
       }
     }

--- a/src/CLI/usbguard-block-device.cpp
+++ b/src/CLI/usbguard-block-device.cpp
@@ -104,7 +104,10 @@ namespace usbguard
       for (auto rule_device : ipc.listDevices(argv[0])) {
         if (rule.appliesTo(rule_device)) {
           id = rule_device.getRuleID();
-          ipc.applyDevicePolicy(id, Rule::Target::Block, permanent);
+          try {
+            ipc.applyDevicePolicy(id, Rule::Target::Block, permanent);
+          }
+          catch (const usbguard::Exception& ex) {}
         }
       }
     }

--- a/src/CLI/usbguard-reject-device.cpp
+++ b/src/CLI/usbguard-reject-device.cpp
@@ -104,7 +104,10 @@ namespace usbguard
       for (auto rule_device : ipc.listDevices(argv[0])) {
         if (rule.appliesTo(rule_device)) {
           id = rule_device.getRuleID();
-          ipc.applyDevicePolicy(id, Rule::Target::Reject, permanent);
+          try {
+            ipc.applyDevicePolicy(id, Rule::Target::Reject, permanent);
+          }
+          catch (const usbguard::Exception& ex) {}
         }
       }
     }


### PR DESCRIPTION
Let's assume that you want to allow a set of devices by typing only a single rule and that certain rule applies to multiple devices.

If there are at least two devices, where the first one is a controller and the second one is its child, then after blocking the first device, the second one is automatically removed. However, usbguard will try to block it too, because the rule applies to that device. Thus, an error message might appear indicating that the device is not available.

My problem is that when the ```try { ... }``` block is executed, there might appear some warnings when the device can not be found. Do you think that it would be better to extend the interface with something like that:
```if (ipc.isDeviceAvailable(id)) ...``` or maybe other suggestions?