### PR TITLE
Skip failing test in travis-ci

### DIFF
--- a/src/Tests/UseCase/002_cli_devices.sh
+++ b/src/Tests/UseCase/002_cli_devices.sh
@@ -81,7 +81,7 @@ EOF
 
 # Create a dummy USB mass storage device
 sudo -n dd bs=4096 count=1 if=/dev/zero of=/tmp/usbguard_disk
-sudo -n modprobe dummy_hcd
+sudo -n modprobe dummy_hcd || exit 77 # Skip test if dummy_hcd is missing
 sudo -n rmmod g_mass_storage
 sudo -n modprobe g_mass_storage file=/tmp/usbguard_disk iSerialNumber=555666111
 


### PR DESCRIPTION
Test 002_devices.sh is failing due to missing dummy_hcd kernel module. In order to make dummy_hcd work, its necessary to download the kernel, manually add and compile module dummy_hcd. However kernel module needs to be signed (due to secure boot) and for that a reboot (to allow new signature) is necessary, which does not seem to be possible to automate. Other option would be to write a test only for already present USB devices (for example: USB host controller), but no USB is present by default on travis-ci virtual machines. Therefore we skip this test for now.