### PR TITLE
Fix rule filtering by label

### DIFF
--- a/src/Daemon/Daemon.cpp
+++ b/src/Daemon/Daemon.cpp
@@ -765,7 +765,7 @@ namespace usbguard
 
     for (auto ruleset : _policy.getRuleSet()) {
       for (auto const& rule : ruleset->getRules()) {
-        if (label.empty() || rule->getLabel() == label) {
+        if (label.empty() || (!rule->attributeLabel().empty() && rule->getLabel() == label)) {
           rules.push_back(*rule);
         }
       }


### PR DESCRIPTION
Calling usbguard list-rules with option --label fails if at least one rule does not have label attribute set.

closes #328