### PR TITLE
Fix oss-fuzz build, by adding unistd.h to FDInputStream.hpp.

### DIFF
--- a/src/Common/FDInputStream.hpp
+++ b/src/Common/FDInputStream.hpp
@@ -29,6 +29,7 @@
 #endif /* !HAVE_EXT_STDIO_FILEBUF_H */
 #include <fstream>
 #include <memory>
+#include <unistd.h>
 
 namespace usbguard
 {


### PR DESCRIPTION
This resolves the following build error for usbguard on oss-fuzz:

Step #4: In file included from src/Library/DeviceBase.cpp:26:
Step #4: ./src/Common/FDInputStream.hpp:65:15: error: use of undeclared identifier 'read'
Step #4:         ret = read(fd_, s, n);