### PR TITLE
Generate default RuleSet in case RuleFolder is specified but it's empty

### DIFF
--- a/src/Daemon/RuleSetFactory.cpp
+++ b/src/Daemon/RuleSetFactory.cpp
@@ -74,7 +74,8 @@ namespace usbguard
           ruleSet.push_back(rs);
         }
       }
-      else if (ns.getRulesPath().empty()){
+
+      if (ruleSet.empty()){
         USBGUARD_LOG(Warning) << "RuleFile not set; Modification of the permanent policy won't be possible.";
         ruleSet = generateDefaultRuleSet();
       }


### PR DESCRIPTION
This commit solves the following:

- If RuleFile is not listed in the usbguard-daemon configuration file but RuleFolder is and at the same time RuleFolder is an empty directory then it would give a segmentation fault because RuleSet is not initialized.