### PR TITLE
Extend allow/block/reject-device commands to accept a rule as a single argument(in apostrophes)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 env:
   global:
-  - secure: "mAKqsfksFjBmvtjVEUiUkJ1rG7pp4dGZrTez2SRoEu+bEDh620O931SwBYyWMAdKRNGt9zrV22EASXM9ug1AHboFTOnMM17YCLw/nbioV92EIYV7O+infO9dkGpn0wDVa/jPIiJB++5xeeIF8Lgq7td6wP4jE8WMl97PL5wtEMs="
+    - secure: mAKqsfksFjBmvtjVEUiUkJ1rG7pp4dGZrTez2SRoEu+bEDh620O931SwBYyWMAdKRNGt9zrV22EASXM9ug1AHboFTOnMM17YCLw/nbioV92EIYV7O+infO9dkGpn0wDVa/jPIiJB++5xeeIF8Lgq7td6wP4jE8WMl97PL5wtEMs=
+    - XML_CATALOG_FILES="/etc/xml/catalog"
 language: cpp
 compiler:
 - clang
@@ -87,7 +88,7 @@ before_install:
 - sudo apt-get install -y libprotobuf-dev protobuf-compiler
 - sudo apt-get install -y libldap-dev
 - sudo apt-get install -y valgrind
-- sudo apt-get install -y asciidoc docbook-xml
+- sudo apt-get install -y asciidoc docbook-xml docbook-xsl
 - sudo apt-get install -y umockdev libumockdev-dev
 - sudo gem install coveralls-lcov
 - sudo apt-get install clang
@@ -104,7 +105,7 @@ install:
 - ansible-playbook -i ./hosts -u root --connection=local playbook.yml
 - popd
 - pushd /tmp
-- wget https://github.com/protocolbuffers/protobuf/releases/download/v3.11.3/protobuf-cpp-3.11.3.tar.gz
+- wget --retry-on-http-error=429 --timeout=1 --tries=20 https://github.com/protocolbuffers/protobuf/releases/download/v3.11.3/protobuf-cpp-3.11.3.tar.gz
 - tar -xzvf protobuf-cpp-3.11.3.tar.gz
 - CXXB=${CXX}
 - CXX=g++

--- a/Makefile.am
+++ b/Makefile.am
@@ -16,6 +16,7 @@
 ##
 ## Authors: Daniel Kopecek <dkopecek@redhat.com>
 ##          Jiri Vymazal   <jvymazal@redhat.com>
+##          Attila Lakatos <alakatos@redhat.com>
 ##
 SUBDIRS=src/Tests/
 
@@ -395,6 +396,8 @@ usbguard_SOURCES=\
 	src/CLI/usbguard-block-device.cpp \
 	src/CLI/usbguard-reject-device.hpp \
 	src/CLI/usbguard-reject-device.cpp \
+	src/CLI/usbguard-apply-device-policy.hpp \
+	src/CLI/usbguard-apply-device-policy.cpp \
 	src/CLI/usbguard-list-rules.hpp \
 	src/CLI/usbguard-list-rules.cpp \
 	src/CLI/usbguard-append-rule.hpp \

--- a/src/CLI/usbguard-allow-device.cpp
+++ b/src/CLI/usbguard-allow-device.cpp
@@ -15,6 +15,7 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 //
 // Authors: Daniel Kopecek <dkopecek@redhat.com>
+//          Attila Lakatos <alakatos@redhat.com>
 //
 #ifdef HAVE_BUILD_CONFIG_H
   #include <build-config.h>
@@ -22,97 +23,15 @@
 
 #include "usbguard.hpp"
 #include "usbguard-allow-device.hpp"
-#include "usbguard/RuleParser.hpp"
-#include "Common/Utility.hpp"
-
-#include "usbguard/IPCClient.hpp"
+#include "usbguard-apply-device-policy.hpp"
 
 #include <iostream>
 
 namespace usbguard
 {
-  static const char* options_short = "hp";
-
-  static const struct ::option options_long[] = {
-    { "help", no_argument, nullptr, 'h' },
-    { "permanent", no_argument, nullptr, 'p' },
-    { nullptr, 0, nullptr, 0 }
-  };
-
-  static void showHelp(std::ostream& stream)
-  {
-    stream << " Usage: " << usbguard_arg0 << " allow-device [OPTIONS] (<device-id> | <rule>)" << std::endl;
-    stream << std::endl;
-    stream << " Options:" << std::endl;
-    stream << "  -p, --permanent  Make the decision permanent. A device specific allow" << std::endl;
-    stream << "                   rule will be appended to or updated in the current policy." << std::endl;
-    stream << "  -h, --help       Show this help." << std::endl;
-    stream << std::endl;
-  }
-
   int usbguard_allow_device(int argc, char* argv[])
   {
-    uint32_t id = 0;
-    bool permanent = false;
-    int opt = 0;
-
-    while ((opt = getopt_long(argc, argv, options_short, options_long, nullptr)) != -1) {
-      switch (opt) {
-      case 'h':
-        showHelp(std::cout);
-        return EXIT_SUCCESS;
-
-      case 'p':
-        permanent = true;
-        break;
-
-      case '?':
-        showHelp(std::cerr);
-
-      default:
-        return EXIT_FAILURE;
-      }
-    }
-
-    argc -= optind;
-    argv += optind;
-    usbguard::IPCClient ipc(/*connected=*/true);
-
-    if (argc == 0) {
-      showHelp(std::cerr);
-      return EXIT_FAILURE;
-    }
-    else if (argc == 1) { /* Allow device by ID */
-      id = std::stoul(argv[0]);
-      ipc.applyDevicePolicy(id, Rule::Target::Allow, permanent);
-    }
-    else { /* Allow device by Rule */
-      //Create a string containing each argument(rule)
-      std::vector<std::string> arguments(argv, argv + argc);
-      std::string rule_string = joinElements(arguments.begin(), arguments.end());
-      usbguard::Rule rule;
-
-      try {
-        rule = Rule::fromString(rule_string);
-      }
-      catch (const usbguard::RuleParserError& ex) {
-        std::cerr << "ERROR: " << ex.what() << std::endl;
-        showHelp(std::cerr);
-        return EXIT_FAILURE;
-      }
-
-      for (auto rule_device : ipc.listDevices(argv[0])) {
-        if (rule.appliesTo(rule_device)) {
-          id = rule_device.getRuleID();
-          try {
-            ipc.applyDevicePolicy(id, Rule::Target::Allow, permanent);
-          }
-          catch (const usbguard::Exception& ex) {}
-        }
-      }
-    }
-
-    return EXIT_SUCCESS;
+    return usbguard_apply_device_policy(argc, argv, Rule::Target::Allow);
   }
 } /* namespace usbguard */
 

--- a/src/CLI/usbguard-apply-device-policy.cpp
+++ b/src/CLI/usbguard-apply-device-policy.cpp
@@ -1,0 +1,129 @@
+//
+// Copyright (C) 2020 Red Hat, Inc.
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+// Authors: Attila Lakatos <alakatos@redhat.com>
+//
+#ifdef HAVE_BUILD_CONFIG_H
+  #include <build-config.h>
+#endif
+
+#include "usbguard.hpp"
+#include "usbguard-apply-device-policy.hpp"
+#include "Common/Utility.hpp"
+
+#include "usbguard/IPCClient.hpp"
+
+#include <iostream>
+
+namespace usbguard
+{
+  static const char* options_short = "hp";
+
+  static const struct ::option options_long[] = {
+    { "help", no_argument, nullptr, 'h' },
+    { "permanent", no_argument, nullptr, 'p' },
+    { nullptr, 0, nullptr, 0 }
+  };
+
+  static void showHelp(std::ostream& stream, Rule::Target target)
+  {
+    std::string target_string = Rule::targetToString(target);
+    stream << " Usage: " << usbguard_arg0 << " " << target_string << "-device [OPTIONS] (<device-id> | <rule>)" << std::endl;
+    stream << std::endl;
+    stream << " Options:" << std::endl;
+    stream << "  -p, --permanent  Make the decision permanent. A device specific " << target_string << std::endl;
+    stream << "                   rule will be appended to or updated in the current policy." << std::endl;
+    stream << "  -h, --help       Show this help." << std::endl;
+    stream << std::endl;
+  }
+
+  static bool isNumeric(const std::string& s)
+  {
+    return !s.empty() && std::find_if(s.begin(), s.end(), [](unsigned char c) { return !std::isdigit(c); }) == s.end();
+  }
+
+  int usbguard_apply_device_policy(int argc, char** argv, Rule::Target target)
+  {
+    uint32_t id = 0;
+    bool permanent = false;
+    int opt = 0;
+
+    while ((opt = getopt_long(argc, argv, options_short, options_long, nullptr)) != -1) {
+      switch (opt) {
+      case 'h':
+        showHelp(std::cout, target);
+        return EXIT_SUCCESS;
+
+      case 'p':
+        permanent = true;
+        break;
+
+      case '?':
+        showHelp(std::cerr, target);
+
+      default:
+        return EXIT_FAILURE;
+      }
+    }
+
+    argc -= optind;
+    argv += optind;
+    usbguard::IPCClient ipc(/*connected=*/true);
+
+    if (argc == 0) {
+      showHelp(std::cerr, target);
+      return EXIT_FAILURE;
+    }
+    else if (argc == 1 && isNumeric(std::string(argv[0]))) { /* Change device policy by ID */
+      id = std::stoul(argv[0]);
+      ipc.applyDevicePolicy(id, target, permanent);
+    }
+    else { /* Change device policy by Rule */
+      std::string rule_string;
+      if (argc == 1)
+        rule_string = argv[0];
+      else {
+        std::vector<std::string> arguments(argv, argv + argc);
+        rule_string = joinElements(arguments.begin(), arguments.end());
+      }
+
+      usbguard::Rule rule;
+      try {
+        rule = Rule::fromString(rule_string);
+      }
+      catch (const usbguard::RuleParserError& ex) {
+        std::cerr << "ERROR: " << ex.what() << std::endl;
+        showHelp(std::cerr, target);
+        return EXIT_FAILURE;
+      }
+
+      std::string rule_target = rule_string.substr(0, rule_string.find(" "));
+      for (auto rule_device : ipc.listDevices(rule_target)) {
+        if (rule.appliesTo(rule_device)) {
+          id = rule_device.getRuleID();
+          try {
+            ipc.applyDevicePolicy(id, target, permanent);
+          }
+          catch (const usbguard::Exception& ex) {}
+        }
+      }
+    }
+
+    return EXIT_SUCCESS;
+  }
+} /* namespace usbguard */
+
+/* vim: set ts=2 sw=2 et */

--- a/src/CLI/usbguard-apply-device-policy.hpp
+++ b/src/CLI/usbguard-apply-device-policy.hpp
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2016 Red Hat, Inc.
+// Copyright (C) 2020 Red Hat, Inc.
 //
 // This program is free software; you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -14,25 +14,18 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 //
-// Authors: Daniel Kopecek <dkopecek@redhat.com>
-//          Attila Lakatos <alakatos@redhat.com>
+// Authors: Attila Lakatos <alakatos@redhat.com>
 //
+#pragma once
 #ifdef HAVE_BUILD_CONFIG_H
   #include <build-config.h>
 #endif
 
-#include "usbguard.hpp"
-#include "usbguard-reject-device.hpp"
-#include "usbguard-apply-device-policy.hpp"
-
-#include <iostream>
+#include "usbguard/RuleParser.hpp"
 
 namespace usbguard
 {
-  int usbguard_reject_device(int argc, char* argv[])
-  {
-    return usbguard_apply_device_policy(argc, argv, Rule::Target::Reject);
-  }
+  int usbguard_apply_device_policy(int argc, char** argv, Rule::Target target);
 } /* namespace usbguard */
 
 /* vim: set ts=2 sw=2 et */

--- a/src/CLI/usbguard-block-device.cpp
+++ b/src/CLI/usbguard-block-device.cpp
@@ -15,6 +15,7 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 //
 // Authors: Daniel Kopecek <dkopecek@redhat.com>
+//          Attila Lakatos <alakatos@redhat.com>
 //
 #ifdef HAVE_BUILD_CONFIG_H
   #include <build-config.h>
@@ -22,97 +23,15 @@
 
 #include "usbguard.hpp"
 #include "usbguard-block-device.hpp"
-#include "usbguard/RuleParser.hpp"
-#include "Common/Utility.hpp"
-
-#include "usbguard/IPCClient.hpp"
+#include "usbguard-apply-device-policy.hpp"
 
 #include <iostream>
 
 namespace usbguard
 {
-  static const char* options_short = "hp";
-
-  static const struct ::option options_long[] = {
-    { "help", no_argument, nullptr, 'h' },
-    { "permanent", no_argument, nullptr, 'p' },
-    { nullptr, 0, nullptr, 0 }
-  };
-
-  static void showHelp(std::ostream& stream)
-  {
-    stream << " Usage: " << usbguard_arg0 << " block-device [OPTIONS] (<device-id> | <rule>)" << std::endl;
-    stream << std::endl;
-    stream << " Options:" << std::endl;
-    stream << "  -p, --permanent  Make the decision permanent. A device specific block" << std::endl;
-    stream << "                   rule will be appended to or updated in the current policy." << std::endl;
-    stream << "  -h, --help       Show this help." << std::endl;
-    stream << std::endl;
-  }
-
   int usbguard_block_device(int argc, char* argv[])
   {
-    uint32_t id = 0;
-    bool permanent = false;
-    int opt = 0;
-
-    while ((opt = getopt_long(argc, argv, options_short, options_long, nullptr)) != -1) {
-      switch (opt) {
-      case 'h':
-        showHelp(std::cout);
-        return EXIT_SUCCESS;
-
-      case 'p':
-        permanent = true;
-        break;
-
-      case '?':
-        showHelp(std::cerr);
-
-      default:
-        return EXIT_FAILURE;
-      }
-    }
-
-    argc -= optind;
-    argv += optind;
-    usbguard::IPCClient ipc(/*connected=*/true);
-
-    if (argc == 0) {
-      showHelp(std::cerr);
-      return EXIT_FAILURE;
-    }
-    else if (argc == 1) { /* Block device by ID */
-      id = std::stoul(argv[0]);
-      ipc.applyDevicePolicy(id, Rule::Target::Block, permanent);
-    }
-    else { /* Block device by Rule */
-      //Create a string containing each argument(rule)
-      std::vector<std::string> arguments(argv, argv + argc);
-      std::string rule_string = joinElements(arguments.begin(), arguments.end());
-      usbguard::Rule rule;
-
-      try {
-        rule = Rule::fromString(rule_string);
-      }
-      catch (const usbguard::RuleParserError& ex) {
-        std::cerr << "ERROR: " << ex.what() << std::endl;
-        showHelp(std::cerr);
-        return EXIT_FAILURE;
-      }
-
-      for (auto rule_device : ipc.listDevices(argv[0])) {
-        if (rule.appliesTo(rule_device)) {
-          id = rule_device.getRuleID();
-          try {
-            ipc.applyDevicePolicy(id, Rule::Target::Block, permanent);
-          }
-          catch (const usbguard::Exception& ex) {}
-        }
-      }
-    }
-
-    return EXIT_SUCCESS;
+    return usbguard_apply_device_policy(argc, argv, Rule::Target::Block);
   }
 } /* namespace usbguard */
 


### PR DESCRIPTION
Commit ecd99dba7a94708e9a4a72ca831bde283db3ec26 ensures that ```allow-device``` command will accept a rule as a single argument, so we do not have to escape special characters. Old behavior can also be used.
Besides that this commit fixes an error, when the rule consists of only one argument, e.g. ```usbguard allow-device block``` for allowing all blocked devices (fixes #413).
The same applies for ```block-device``` and ```reject-device```.

Commit 534236680efc80ec508e801ed3c27f75d8ee339f fixes two errors connected with travis:

- Set env variable XML_CATALOG_FILES for xmllint
- Allow ```wget``` to retry if server returns 429(too many requests)