### PR TITLE
Remove root permission check option

### DIFF
--- a/doc/man/usbguard.1.adoc
+++ b/doc/man/usbguard.1.adoc
@@ -261,9 +261,6 @@ Available options:
 *-P, --parameters* 'privileges'::
     Run-time parameter related privileges.
 
-*-N, --no-root-check*::
-    Disable root privileges checking.
-
 *-h, --help*::
     Show help.
 
@@ -289,9 +286,6 @@ Available options:
 
 *-g, --group*::
     The specified 'name' represents a groupname or GID.
-
-*-N, --no-root-check*::
-    Disable root privileges checking.
 
 *-h, --help*::
     Show help.

--- a/src/CLI/usbguard-add-user.cpp
+++ b/src/CLI/usbguard-add-user.cpp
@@ -27,13 +27,12 @@
 #include "usbguard/IPCServer.hpp"
 
 #include <iostream>
-
 #include <unistd.h>
 #include <sys/stat.h>
 
 namespace usbguard
 {
-  static const char* options_short = "hugp:d:e:P:N";
+  static const char* options_short = "hugp:d:e:P:";
 
   static const struct ::option options_long[] = {
     { "help", no_argument, nullptr, 'h' },
@@ -43,7 +42,6 @@ namespace usbguard
     { "devices", required_argument, nullptr, 'd' },
     { "exceptions", required_argument, nullptr, 'e' },
     { "parameters", required_argument, nullptr, 'P' },
-    { "no-root-check", no_argument, nullptr, 'N' },
     { nullptr, 0, nullptr, 0 }
   };
 
@@ -58,7 +56,6 @@ namespace usbguard
     stream << "  -d, --devices <privileges>     Device related privileges." << std::endl;
     stream << "  -e, --exceptions <privileges>  Exceptions related privileges." << std::endl;
     stream << "  -P, --parameters <privileges>  Run-time parameter related privileges." << std::endl;
-    stream << "  -N, --no-root-check            Disable root privileges checking." << std::endl;
     stream << "  -h, --help                     Show this help." << std::endl;
     stream << std::endl;
   }
@@ -88,7 +85,6 @@ namespace usbguard
   {
     int opt = 0;
     bool opt_is_group = false;
-    bool opt_no_root_check = false;
     IPCServer::AccessControl access_control;
 
     while ((opt = getopt_long(argc, argv, options_short, options_long, nullptr)) != -1) {
@@ -121,10 +117,6 @@ namespace usbguard
         access_control.merge(std::string("Parameters=").append(optarg));
         break;
 
-      case 'N':
-        opt_no_root_check = true;
-        break;
-
       case '?':
         showHelp(std::cerr);
 
@@ -141,11 +133,9 @@ namespace usbguard
       return EXIT_FAILURE;
     }
 
-    if (!opt_no_root_check) {
-      if (!(getuid() == 0 && geteuid() == 0)) {
-        USBGUARD_LOG(Error) << "This subcommand requires root privileges. Please retry as root.";
-        return EXIT_FAILURE;
-      }
+    if (!(getuid() == 0 && geteuid() == 0)) {
+      USBGUARD_LOG(Error) << "This subcommand requires root privileges. Please retry as root.";
+      return EXIT_FAILURE;
     }
 
     const std::string name(argv[0]);

--- a/src/CLI/usbguard-remove-user.cpp
+++ b/src/CLI/usbguard-remove-user.cpp
@@ -27,18 +27,16 @@
 #include "usbguard/IPCServer.hpp"
 
 #include <iostream>
-
 #include <unistd.h>
 
 namespace usbguard
 {
-  static const char* options_short = "hugN";
+  static const char* options_short = "hug";
 
   static const struct ::option options_long[] = {
     { "help", no_argument, nullptr, 'h' },
     { "user", no_argument, nullptr, 'u' },
     { "group", no_argument, nullptr, 'g' },
-    { "no-root-check", no_argument, nullptr, 'N' },
     { nullptr, 0, nullptr, 0  }
   };
 
@@ -49,7 +47,6 @@ namespace usbguard
     stream << " Options:" << std::endl;
     stream << "  -u, --user           The specified name represents a username or UID (default)." << std::endl;
     stream << "  -g, --group          The specified name represents a groupname or GID." << std::endl;
-    stream << "  -N, --no-root-check  Disable root privileges checking." << std::endl;
     stream << "  -h, --help           Show this help." << std::endl;
     stream << std::endl;
   }
@@ -70,7 +67,6 @@ namespace usbguard
   {
     int opt = 0;
     bool opt_is_group = false;
-    bool opt_no_root_check = false;
 
     while ((opt = getopt_long(argc, argv, options_short, options_long, nullptr)) != -1) {
       switch (opt) {
@@ -85,10 +81,6 @@ namespace usbguard
       case 'h':
         showHelp(std::cout);
         return EXIT_SUCCESS;
-
-      case 'N':
-        opt_no_root_check = true;
-        break;
 
       case '?':
         showHelp(std::cerr);
@@ -106,11 +98,9 @@ namespace usbguard
       return EXIT_FAILURE;
     }
 
-    if (!opt_no_root_check) {
-      if (!(getuid() == 0 && geteuid() == 0)) {
-        USBGUARD_LOG(Error) << "This subcommand requires root privileges. Please retry as root.";
-        return EXIT_FAILURE;
-      }
+    if (!(getuid() == 0 && geteuid() == 0)) {
+      USBGUARD_LOG(Error) << "This subcommand requires root privileges. Please retry as root.";
+      return EXIT_FAILURE;
     }
 
     const std::string name(argv[0]);


### PR DESCRIPTION
No root check option is currently not working due to the fact that CLI will still need root permissions to read usbguard-daemon.conf file. This option should be removed as there does not seem to be any rational reason for its existence within usbguard.