### PR TITLE
Extend public API - Allow IPC Client to query IPC permissions

### DIFF
--- a/src/Library/IPC/Policy.proto
+++ b/src/Library/IPC/Policy.proto
@@ -40,11 +40,29 @@ message removeRuleRequest {
 }
 
 message removeRuleResponse {
-  required uint32 id = 1;  
+  required uint32 id = 1;
 }
 
 message removeRule {
   required MessageHeader header = 1;
   required removeRuleRequest request = 2;
   optional removeRuleResponse response = 3;
+}
+
+
+message checkIPCPermissionsRequest {
+  required uint32 uid = 1;
+  required uint32 gid = 2;
+  required string section = 3;
+  required string privilege = 4;
+}
+
+message checkIPCPermissionsResponse {
+  required bool permit = 1;
+}
+
+message checkIPCPermissions {
+  required MessageHeader header = 1;
+  required checkIPCPermissionsRequest request = 2;
+  optional checkIPCPermissionsResponse response = 3;
 }

--- a/src/Library/IPCClientPrivate.hpp
+++ b/src/Library/IPCClientPrivate.hpp
@@ -65,6 +65,8 @@ namespace usbguard
     uint32_t applyDevicePolicy(uint32_t id, Rule::Target target, bool permanent);
     const std::vector<Rule> listDevices(const std::string& query);
 
+    bool checkIPCPermissions(const IPCServer::AccessControl::Section& section, const IPCServer::AccessControl::Privilege& privilege);
+
     void processReceiveEvent();
 
   private:

--- a/src/Library/IPCPrivate.cpp
+++ b/src/Library/IPCPrivate.cpp
@@ -44,7 +44,8 @@ namespace usbguard
     { 0x08, "usbguard.IPC.removeRule" },
     { 0x09, "usbguard.IPC.Exception" },
     { 0x0a, "usbguard.IPC.getParameter" },
-    { 0x0b, "usbguard.IPC.setParameter" }
+    { 0x0b, "usbguard.IPC.setParameter" },
+    { 0x0c, "usbguard.IPC.checkIPCPermissions" }
   };
 
   uint32_t IPC::messageTypeNameToNumber(const std::string& name)

--- a/src/Library/IPCServerPrivate.cpp
+++ b/src/Library/IPCServerPrivate.cpp
@@ -84,6 +84,8 @@ namespace usbguard
       IPCServer::AccessControl::Privilege::MODIFY);
     registerHandler<IPC::getParameter>(&IPCServerPrivate::handleGetParameter, IPCServer::AccessControl::Section::PARAMETERS,
       IPCServer::AccessControl::Privilege::LIST);
+    registerHandler<IPC::checkIPCPermissions>(&IPCServerPrivate::handleCheckIPCPermissions, IPCServer::AccessControl::Section::ALL,
+      IPCServer::AccessControl::Privilege::NONE);
   }
 
   void IPCServerPrivate::initIPC()
@@ -987,6 +989,22 @@ namespace usbguard
     IPC::getParameter* const message_out = message_in->New();
     message_out->MergeFrom(*message_in);
     message_out->mutable_response()->set_value(value);
+    response.reset(message_out);
+  }
+
+  void IPCServerPrivate::handleCheckIPCPermissions(IPC::MessagePointer& request, IPC::MessagePointer& response)
+  {
+    const IPC::checkIPCPermissions* const message_in = static_cast<const IPC::checkIPCPermissions*>(request.get());
+    uid_t uid = message_in->request().uid();
+    gid_t gid = message_in->request().gid();
+    IPCServer::AccessControl access_control = IPCServer::AccessControl();
+    const bool auth = qbIPCConnectionAllowed(uid, gid, &access_control);
+    IPCServer::AccessControl::Section section = IPCServer::AccessControl::sectionFromString(message_in->request().section());
+    IPCServer::AccessControl::Privilege privilege = IPCServer::AccessControl::privilegeFromString(message_in->request().privilege());
+    const bool permit = auth && access_control.hasPrivilege(section, privilege);
+    IPC::checkIPCPermissions* const message_out = message_in->New();
+    message_out->MergeFrom(*message_in);
+    message_out->mutable_response()->set_permit(permit);
     response.reset(message_out);
   }
 

--- a/src/Library/IPCServerPrivate.hpp
+++ b/src/Library/IPCServerPrivate.hpp
@@ -143,6 +143,8 @@ namespace usbguard
     void handleSetParameter(IPC::MessagePointer& request, IPC::MessagePointer& response);
     void handleGetParameter(IPC::MessagePointer& request, IPC::MessagePointer& response);
 
+    void handleCheckIPCPermissions(IPC::MessagePointer& request, IPC::MessagePointer& response);
+
     IPCServer& _p_instance;
 
     qb_loop_t* _qb_loop;

--- a/src/Library/public/usbguard/IPCClient.cpp
+++ b/src/Library/public/usbguard/IPCClient.cpp
@@ -86,6 +86,11 @@ namespace usbguard
   {
     return d_pointer->listDevices(query);
   }
+
+  bool IPCClient::checkIPCPermissions(const IPCServer::AccessControl::Section& section, const IPCServer::AccessControl::Privilege& privilege)
+  {
+    return d_pointer->checkIPCPermissions(section, privilege);
+  }
 } /* namespace usbguard */
 
 /* vim: set ts=2 sw=2 et */

--- a/src/Library/public/usbguard/IPCClient.hpp
+++ b/src/Library/public/usbguard/IPCClient.hpp
@@ -21,6 +21,7 @@
 #include "DeviceManager.hpp"
 #include "Exception.hpp"
 #include "Interface.hpp"
+#include "IPCServer.hpp"
 #include "Typedefs.hpp"
 
 #include <string>
@@ -28,6 +29,9 @@
 #include <memory>
 
 #include <cstdint>
+#include <unistd.h>
+#include <sys/types.h>
+
 
 namespace usbguard
 {
@@ -149,6 +153,17 @@ namespace usbguard
     {
       return listDevices("match");
     }
+
+    /**
+     * @brief Check if IPC client has enough permission for queried section with privilege.
+     *
+     * @param section Section to be checked for.
+     * @param privilege Privilege to be checked for.
+     *
+     * @return True if IPC client has enough permission
+     * for (section, privilege), otherwise false.
+     */
+    bool checkIPCPermissions(const IPCServer::AccessControl::Section& section, const IPCServer::AccessControl::Privilege& privilege);
 
     /**
      * @brief Defines algorithm to perform in the case of IPC connection.

--- a/src/Library/public/usbguard/IPCServer.cpp
+++ b/src/Library/public/usbguard/IPCServer.cpp
@@ -135,6 +135,10 @@ namespace usbguard
   bool IPCServer::AccessControl::hasPrivilege(IPCServer::AccessControl::Section section,
     IPCServer::AccessControl::Privilege privilege) const
   {
+    if (privilege == Privilege::NONE) {
+      return true;
+    }
+
     if (section == Section::ALL || section == Section::NONE) {
       throw USBGUARD_BUG("Cannot test against ALL, NONE sections");
     }


### PR DESCRIPTION
Allow IPC Client to ask IPC server for a certain AccessControl(Section, Privilege). To get a better understanding about this problem I implemented the ```check-IPC-permission``` CLI command to test the functionality.
Syntax: ```usbguard check-IPC-permission --section Policy --privilege modify```
This can be deleted after change is aproved and before it is merged.

This would help with https://github.com/Cropi/usbguard-notifier/pull/62#issuecomment-681157855

Help needed:
- [x] Right now, it is not possible to check IPC permission for ALL and NONE section and privilege. **Maybe** we should extend ```IPCServer::AccessControl::hasPrivilege```  with that. The reason I did not do that is it might have some unexpected consequences.
- [x] The use of ```checkIPCpermission(section, privilege)``` requires Section=ALL, Privilege=None permissions, is this the right approach? 