### PR TITLE
Use partial rule in allow/block/reject-device commands

### DIFF
--- a/doc/man/usbguard-rules.conf.5.adoc
+++ b/doc/man/usbguard-rules.conf.5.adoc
@@ -241,6 +241,11 @@ List of conditions:
     Evaluates always to false.
 
 
+=== Partial rule
+Partial rule is a rule without a rule target.
+Partial rules may by used by some commands of *usbguard* CLI tool.
+
+
 == Initial policy
 Using the *usbguard* CLI tool and its *generate-policy* subcommand, you can generate an initial policy for your system instead of writing one from scratch.
 The tool generates an *allow* policy for all devices connected to the system at the time of execution.

--- a/doc/man/usbguard.1.adoc
+++ b/doc/man/usbguard.1.adoc
@@ -17,11 +17,11 @@ usbguard set-parameter 'name' 'value'
 
 usbguard list-devices
 
-usbguard allow-device 'id' | 'rule'
+usbguard allow-device 'id' | 'partial-rule'
 
-usbguard block-device 'id' | 'rule'
+usbguard block-device 'id' | 'partial-rule'
 
-usbguard reject-device 'id' | 'rule'
+usbguard reject-device 'id' | 'partial-rule'
 
 usbguard list-rules
 
@@ -85,8 +85,11 @@ Available options:
     Show help.
 
 
-=== *allow-device* ['OPTIONS'] < 'id' | 'rule' >
-Authorize a device identified by either the device 'id' or a specific 'rule' to interact with the system. A rule might apply to multiple devices. Note that the device 'id' refers to the very first number of the list-devices command output.
+=== *allow-device* ['OPTIONS'] < 'id' | 'partial-rule' >
+Authorize a device to interact with the system.
+Device can be identified by either a device 'id' or a 'partial-rule'.
+Partial rule can be used to allow multiple devices at once.
+Note that the device 'id' refers to the very first number of the list-devices command output.
 
 Available options:
 
@@ -98,8 +101,11 @@ Available options:
     Show help.
 
 
-=== *block-device* ['OPTIONS'] < 'id' | 'rule' >
-Deauthorize a device identified by either the device 'id' or a specific 'rule'. A rule might apply to multiple devices. Note that the device 'id' refers to the very first number of the list-devices command output.
+=== *block-device* ['OPTIONS'] < 'id' | 'partial-rule' >
+Deauthorize a device.
+Device can be identified by either a device 'id' or a 'partial-rule'.
+Partial rule can be used to block multiple devices at once.
+Note that the device 'id' refers to the very first number of the list-devices command output.
 
 Available options:
 
@@ -111,8 +117,11 @@ Available options:
     Show help.
 
 
-=== *reject-device* ['OPTIONS'] < 'id' | 'rule' >
-Deauthorize and remove a device identified by either the device 'id' or a specific 'rule'. A rule might apply to multiple devices. Note that the device 'id' refers to the very first number of the list-devices command output.
+=== *reject-device* ['OPTIONS'] < 'id' | 'partial-rule' >
+Deauthorize and remove a device.
+Device can be identified by either a device 'id' or a 'partial-rule'.
+Partial rule can be used to reject multiple devices at once.
+Note that the device 'id' refers to the very first number of the list-devices command output.
 
 Available options:
 


### PR DESCRIPTION
This is rather quality of life change. It enables users to write partial rule (rule without target specified) on commands like allow-device. When a user wants to allow a device with allow-device, he will not need to write a complete rule, for example: usbguard allow-device block name "MyUSB" but instead he can write usbguard allow-device name "MyUSB". Same holds for block-device and reject-device commands.