### PR TITLE
Get rules file names from directory in alphabetical order

### DIFF
--- a/src/Common/Utility.cpp
+++ b/src/Common/Utility.cpp
@@ -539,6 +539,7 @@ namespace usbguard
 
     // cleanup
     closedir(dir_fd);
+    std::sort(rulefile_list.begin(), rulefile_list.end());
     return rulefile_list;
   }
 } /* namespace usbguard */


### PR DESCRIPTION
On some distributions, rules files are not loaded in alpha-numeric order. The list of rules file names needs to be sorted before using it.