### PR TITLE
Allow/block/reject-device commands support both rule and partial-rule

### DIFF
--- a/doc/man/example-allow-device.adoc
+++ b/doc/man/example-allow-device.adoc
@@ -1,6 +1,6 @@
 ....
     # Allow a device by ID(it is the very first number from the list-devices command output)
     $ sudo usbguard allow-device 10
-    # Allow all the devices named "Dell Wired Multimedia Keyboard"
-    $ sudo usbguard allow-device match name \"Dell Wired Multimedia Keyboard\"
+    # Allow all devices named "Dell Wired Multimedia Keyboard"
+    $ sudo usbguard allow-device name \"Dell Wired Multimedia Keyboard\"
 ....

--- a/doc/man/usbguard.1.adoc
+++ b/doc/man/usbguard.1.adoc
@@ -17,11 +17,11 @@ usbguard set-parameter 'name' 'value'
 
 usbguard list-devices
 
-usbguard allow-device 'id' | 'partial-rule'
+usbguard allow-device 'id' | 'rule' | 'partial-rule'
 
-usbguard block-device 'id' | 'partial-rule'
+usbguard block-device 'id' | 'rule' | 'partial-rule'
 
-usbguard reject-device 'id' | 'partial-rule'
+usbguard reject-device 'id' | 'rule' | 'partial-rule'
 
 usbguard list-rules
 
@@ -85,11 +85,11 @@ Available options:
     Show help.
 
 
-=== *allow-device* ['OPTIONS'] < 'id' | 'partial-rule' >
+=== *allow-device* ['OPTIONS'] < 'id' | 'rule' | 'partial-rule' >
 Authorize a device to interact with the system.
-Device can be identified by either a device 'id' or a 'partial-rule'.
-Partial rule can be used to allow multiple devices at once.
-Note that the device 'id' refers to the very first number of the list-devices command output.
+The device can be identified by either a device 'id', 'rule' or 'partial-rule' (rule without target).
+Both 'rule' and 'partial-rule' can be used to allow multiple devices at once.
+Note that 'id' refers to the internal device-rule ID (the very first number of the list-devices command output) rather than the device's ID attribute.
 
 Available options:
 
@@ -101,11 +101,11 @@ Available options:
     Show help.
 
 
-=== *block-device* ['OPTIONS'] < 'id' | 'partial-rule' >
+=== *block-device* ['OPTIONS'] < 'id' | 'rule' | 'partial-rule' >
 Deauthorize a device.
-Device can be identified by either a device 'id' or a 'partial-rule'.
-Partial rule can be used to block multiple devices at once.
-Note that the device 'id' refers to the very first number of the list-devices command output.
+The device can be identified by either a device 'id', 'rule' or 'partial-rule' (rule without target).
+Both 'rule' and 'partial-rule' can be used to block multiple devices at once.
+Note that 'id' refers to the internal device-rule ID (the very first number of the list-devices command output) rather than the device's ID attribute.
 
 Available options:
 
@@ -117,11 +117,11 @@ Available options:
     Show help.
 
 
-=== *reject-device* ['OPTIONS'] < 'id' | 'partial-rule' >
+=== *reject-device* ['OPTIONS'] < 'id' | 'rule' | 'partial-rule' >
 Deauthorize and remove a device.
-Device can be identified by either a device 'id' or a 'partial-rule'.
-Partial rule can be used to reject multiple devices at once.
-Note that the device 'id' refers to the very first number of the list-devices command output.
+The device can be identified by either a device 'id', 'rule' or 'partial-rule' (rule without target).
+Both 'rule' and 'partial-rule' can be used to reject multiple devices at once.
+Note that 'id' refers to the internal device-rule ID (the very first number of the list-devices command output) rather than the device's ID attribute.
 
 Available options:
 

--- a/src/CLI/usbguard.cpp
+++ b/src/CLI/usbguard.cpp
@@ -79,9 +79,9 @@ namespace usbguard
     stream << "  get-parameter <name>           Get the value of a runtime parameter." << std::endl;
     stream << "  set-parameter <name> <value>   Set the value of a runtime parameter." << std::endl;
     stream << "  list-devices                   List all USB devices recognized by the USBGuard daemon." << std::endl;
-    stream << "  allow-device <id>              Authorize a device to interact with the system." << std::endl;
-    stream << "  block-device <id>              Deauthorize a device." << std::endl;
-    stream << "  reject-device <id>             Deauthorize and remove a device from the system." << std::endl;
+    stream << "  allow-device <id|rule|p-rule>  Authorize a device to interact with the system." << std::endl;
+    stream << "  block-device <id|rule|p-rule>  Deauthorize a device." << std::endl;
+    stream << "  reject-device <id|rule|p-rule> Deauthorize and remove a device from the system." << std::endl;
     stream << std::endl;
     stream << "  list-rules                     List the rule set (policy) used by the USBGuard daemon." << std::endl;
     stream << "  append-rule <rule>             Append a rule to the rule set." << std::endl;


### PR DESCRIPTION
Making usbguard allow/block/reject-device commands support both rule and partial rule.