### PR TITLE
Double free fix

### DIFF
--- a/src/Library/IPCClientPrivate.hpp
+++ b/src/Library/IPCClientPrivate.hpp
@@ -119,7 +119,7 @@ namespace usbguard
 
     int _wakeup_fd;
 
-    std::mutex _return_mutex;
+    std::mutex _return_mutex, _disconnect_mutex;
     std::map<uint64_t, std::promise<IPC::MessagePointer>> _return_map;
 
     Thread<IPCClientPrivate> _thread;


### PR DESCRIPTION
Commit https://github.com/USBGuard/usbguard/commit/93088a9107b77e588816913b825999825ab8e86d makes IPCClientPrivate@disconnect thread safe, so no double free happens after deallocating IPC resources, fixes #435