### PR TITLE
Do not call processDevicePresence when CHANGE uevent is invoked

### DIFF
--- a/src/Library/UEventDeviceManager.cpp
+++ b/src/Library/UEventDeviceManager.cpp
@@ -345,7 +345,7 @@ namespace usbguard
       uint32_t id = 0;
       const bool known_path = knownSysfsPath(sysfs_devpath, &id);
 
-      if (action == "add" || action == "change") {
+      if (action == "add" /*|| action == "change"*/) {
         if (known_path && id > 0) {
           processDevicePresence(id);
         }


### PR DESCRIPTION
Commit https://github.com/USBGuard/usbguard/commit/f87728ddc679ab5f14a4572adde5f97c760732fc : in some cases, when the policy of a device is changed(e.g. allow -> block), a CHANGE uevent action is invoked. Once it happens, usbguard calls ```processDevicePresence()``` and it changes back the policy(e.g. block -> allow) of that specific device. This is still in progress as I am not not sure about this.
I did some experiments with ```udevadm monitor``` and draw conclusions that we might want to remove action=CHANGE events.