### PR TITLE
Link against libpthread

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -167,6 +167,7 @@ libusbguard_la_CPPFLAGS=\
 	-I$(top_srcdir)/src/Library/public \
 	-I$(top_builddir)/src/Library/IPC \
 	${BOOST_CPPFLAGS} \
+	${PTHREAD_CPPFLAGS} \
 	@qb_CFLAGS@ \
 	@protobuf_CFLAGS@ \
 	@crypto_CFLAGS@ \
@@ -185,7 +186,9 @@ libusbguard_la_LIBADD=\
 	@pegtl_LIBS@ \
 	@atomic_LIBS@ \
 	@umockdev_LIBS@ \
-	${BOOST_IOSTREAMS_LIB}
+	${BOOST_IOSTREAMS_LIB} \
+	${PTHREAD_CFLAGS} \
+	${PTHREAD_LIBS}
 
 EXTRA_DIST+=\
 	src/Library/IPC/Devices.proto \


### PR DESCRIPTION
`CFLAGS` is needed in addition to `LIBS`, because on some systems it
contains `-pthread` and `LIBS` is empty.

Closes: https://github.com/USBGuard/usbguard/issues/432
