### PR TITLE
Add support for PEGTL 3.2.0

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -768,7 +768,7 @@ echo " libseccomp: $libseccomp_summary"
 echo "  libcap-ng: $libcap_ng_summary"
 echo "   protobuf: $protobuf_summary"
 echo "      Catch: $catch_summary"
-echo "      PEGTL: $pegtl_summary; version <= 2.6.0: $have_pegtl_lte_260"
+echo "      PEGTL: $pegtl_summary; version <= 3.2.0: $have_pegtl_lte_320"
 echo "      GDBus: $dbus_summary"
 echo "   umockdev: $umockdev_summary"
 echo

--- a/src/Library/RuleParser/Grammar.hpp
+++ b/src/Library/RuleParser/Grammar.hpp
@@ -34,29 +34,29 @@ namespace usbguard
     /*
      * Rule language keywords
      */
-    struct str_allow : TAOCPP_PEGTL_STRING("allow") {};
-    struct str_block : TAOCPP_PEGTL_STRING("block") {};
-    struct str_reject : TAOCPP_PEGTL_STRING("reject") {};
-    struct str_match : TAOCPP_PEGTL_STRING("match") {};
-    struct str_device : TAOCPP_PEGTL_STRING("device") {};
+    struct str_allow : TAO_PEGTL_STRING("allow") {};
+    struct str_block : TAO_PEGTL_STRING("block") {};
+    struct str_reject : TAO_PEGTL_STRING("reject") {};
+    struct str_match : TAO_PEGTL_STRING("match") {};
+    struct str_device : TAO_PEGTL_STRING("device") {};
 
-    struct str_name : TAOCPP_PEGTL_STRING("name") {};
-    struct str_hash : TAOCPP_PEGTL_STRING("hash") {};
-    struct str_parent_hash : TAOCPP_PEGTL_STRING("parent-hash") {};
-    struct str_via_port : TAOCPP_PEGTL_STRING("via-port") {};
-    struct str_with_interface : TAOCPP_PEGTL_STRING("with-interface") {};
-    struct str_with_connect_type : TAOCPP_PEGTL_STRING("with-connect-type") {};
-    struct str_serial : TAOCPP_PEGTL_STRING("serial") {};
-    struct str_if : TAOCPP_PEGTL_STRING("if") {};
-    struct str_id : TAOCPP_PEGTL_STRING("id") {};
-    struct str_label : TAOCPP_PEGTL_STRING("label") {};
+    struct str_name : TAO_PEGTL_STRING("name") {};
+    struct str_hash : TAO_PEGTL_STRING("hash") {};
+    struct str_parent_hash : TAO_PEGTL_STRING("parent-hash") {};
+    struct str_via_port : TAO_PEGTL_STRING("via-port") {};
+    struct str_with_interface : TAO_PEGTL_STRING("with-interface") {};
+    struct str_with_connect_type : TAO_PEGTL_STRING("with-connect-type") {};
+    struct str_serial : TAO_PEGTL_STRING("serial") {};
+    struct str_if : TAO_PEGTL_STRING("if") {};
+    struct str_id : TAO_PEGTL_STRING("id") {};
+    struct str_label : TAO_PEGTL_STRING("label") {};
 
-    struct str_all_of : TAOCPP_PEGTL_STRING("all-of") {};
-    struct str_one_of : TAOCPP_PEGTL_STRING("one-of") {};
-    struct str_none_of : TAOCPP_PEGTL_STRING("none-of") {};
-    struct str_equals : TAOCPP_PEGTL_STRING("equals") {};
-    struct str_equals_ordered : TAOCPP_PEGTL_STRING("equals-ordered") {};
-    struct str_match_all: TAOCPP_PEGTL_STRING("match-all") {};
+    struct str_all_of : TAO_PEGTL_STRING("all-of") {};
+    struct str_one_of : TAO_PEGTL_STRING("one-of") {};
+    struct str_none_of : TAO_PEGTL_STRING("none-of") {};
+    struct str_equals : TAO_PEGTL_STRING("equals") {};
+    struct str_equals_ordered : TAO_PEGTL_STRING("equals-ordered") {};
+    struct str_match_all: TAO_PEGTL_STRING("match-all") {};
 
     /*
      * Generic rule attribute

--- a/src/Library/UEventParser.cpp
+++ b/src/Library/UEventParser.cpp
@@ -28,7 +28,11 @@
 
 #include <fstream>
 
+#if TAO_PEGTL_VERSION_MAJOR >= 3
+#include <tao/pegtl/contrib/trace.hpp>
+#else
 #include <tao/pegtl/contrib/tracer.hpp>
+#endif
 using namespace tao;
 
 namespace usbguard
@@ -130,7 +134,11 @@ namespace usbguard
         tao::pegtl::parse<G, UEventParser::actions>(in, uevent);
       }
       else {
+#if TAO_PEGTL_VERSION_MAJOR >= 3
+        tao::pegtl::complete_trace<G, UEventParser::actions>(in, uevent);
+#else
         tao::pegtl::parse<G, UEventParser::actions, tao::pegtl::tracer>(in, uevent);
+#endif
       }
     }
     catch (...) {

--- a/src/Library/UMockdevDeviceDefinition.cpp
+++ b/src/Library/UMockdevDeviceDefinition.cpp
@@ -26,7 +26,11 @@
 #include <Common/Utility.hpp>
 
 #include <tao/pegtl.hpp>
+#if TAO_PEGTL_VERSION_MAJOR >= 3
+#include <tao/pegtl/contrib/trace.hpp>
+#else
 #include <tao/pegtl/contrib/tracer.hpp>
+#endif
 
 namespace usbguard
 {
@@ -49,12 +53,12 @@ namespace usbguard
      *  S:linkname: device node symlink (without the /dev/ prefix); ignored right now.
      */
 
-    struct str_path_prefix : TAOCPP_PEGTL_STRING("P:") {};
-    struct str_property_prefix : TAOCPP_PEGTL_STRING("E:") {};
-    struct str_ascii_attr_prefix : TAOCPP_PEGTL_STRING("A:") {};
-    struct str_binary_attr_prefix : TAOCPP_PEGTL_STRING("H:") {};
-    struct str_link_prefix : TAOCPP_PEGTL_STRING("L:") {};
-    struct str_name_prefix : TAOCPP_PEGTL_STRING("N:") {};
+    struct str_path_prefix : TAO_PEGTL_STRING("P:") {};
+    struct str_property_prefix : TAO_PEGTL_STRING("E:") {};
+    struct str_ascii_attr_prefix : TAO_PEGTL_STRING("A:") {};
+    struct str_binary_attr_prefix : TAO_PEGTL_STRING("H:") {};
+    struct str_link_prefix : TAO_PEGTL_STRING("L:") {};
+    struct str_name_prefix : TAO_PEGTL_STRING("N:") {};
 
     struct line_rest
       : star<not_at<ascii::eol>, not_at<eof>, ascii::any> {};
@@ -330,7 +334,11 @@ namespace usbguard
 
     try {
       tao::pegtl::string_input<> input(definitions_string, "<string>");
+#if TAO_PEGTL_VERSION_MAJOR >= 3
+      tao::pegtl::complete_trace<UMockdevParser::grammar, UMockdevParser::actions>(input, definitions, umockdev_name);
+#else
       tao::pegtl::parse<UMockdevParser::grammar, UMockdevParser::actions, tao::pegtl::tracer>(input, definitions, umockdev_name);
+#endif
     }
     catch (...) {
       USBGUARD_LOG(Error) << "UMockdevDeviceDefinition: " << "<string>" << ": parsing failed at line <LINE>";

--- a/src/Library/public/usbguard/RuleParser.cpp
+++ b/src/Library/public/usbguard/RuleParser.cpp
@@ -34,7 +34,11 @@
 #include <stdexcept>
 #include <stdlib.h>
 
+#if TAO_PEGTL_VERSION_MAJOR >= 3
+#include <tao/pegtl/contrib/trace.hpp>
+#else
 #include <tao/pegtl/contrib/tracer.hpp>
+#endif
 
 namespace usbguard
 {
@@ -48,7 +52,11 @@ namespace usbguard
         tao::pegtl::parse<RuleParser::rule_grammar, RuleParser::rule_parser_actions>(input, rule);
       }
       else {
+#if TAO_PEGTL_VERSION_MAJOR >= 3
+        tao::pegtl::complete_trace<RuleParser::rule_grammar, RuleParser::rule_parser_actions>(input, rule);
+#else
         tao::pegtl::parse<RuleParser::rule_grammar, RuleParser::rule_parser_actions, tao::pegtl::tracer>(input, rule);
+#endif
       }
 
       return rule;
@@ -56,7 +64,11 @@ namespace usbguard
     catch (const tao::pegtl::parse_error& ex) {
       RuleParserError error(rule_spec);
       error.setHint(ex.what());
+#if TAO_PEGTL_VERSION_MAJOR >= 3
+      error.setOffset(ex.positions().front().column);
+#else
       error.setOffset(ex.positions[0].byte_in_line);
+#endif
 
       if (!file.empty() || line != 0) {
         error.setFileInfo(file, line);


### PR DESCRIPTION
No configuration switches need to be implemented. Now, USBGuard seems to be working with both new and old versions of PEGTL.

Resolves #441 