### PR TITLE
Increase C++ version to c++17

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -15,7 +15,7 @@ image::https://img.shields.io/github/license/USBGuard/usbguard.svg[License, link
 == About
 
 USBGuard is a software framework for implementing USB device authorization policies (what kind of USB devices are authorized) as well as method of use policies (how a USB device may interact with the system).
-Simply put, it is a USB device whitelisting tool.
+Simply put, it is a USB device allowlisting tool.
 
 WARNING: The 0.x releases are not production ready packages.
 They serve for tech-preview and user feedback purposes only.
@@ -35,7 +35,8 @@ Please share your feedback or request a feature in the Github issue trackers for
 
 == Compilation & Installation
 
-To compile the sources from a release tarball, you'll need the development files for:
+To compile the source code, you will require at least C{plus}{plus}17. +
+If you are compiling sources from a release tarball, you'll need the development files for:
 
  * https://github.com/ClusterLabs/libqb[libqb] - used for local UNIX socket based IPC
  * https://github.com/google/protobuf[protobuf] - used for IPC message (de)serialization

--- a/configure.ac
+++ b/configure.ac
@@ -54,7 +54,7 @@ AX_CHECK_COMPILE_FLAG([-Wno-implicit-fallthrough],
 #
 # Final project CXXFLAGS are set after configure checks.
 #
-CXXFLAGS="-std=c++11 $EXTERNAL_CXXFLAGS"
+CXXFLAGS="-std=c++17 $EXTERNAL_CXXFLAGS"
 CFLAGS="-std=c99 $EXTERNAL_CFLAGS"
 CPPFLAGS="-DHAVE_BUILD_CONFIG_H $EXTERNAL_CPPFLAGS"
 
@@ -350,7 +350,7 @@ if test "x$with_bundled_catch" = xyes; then
 	catch_summary="bundled; $catch_CFLAGS $catch_LIBS"
 else
 	SAVE_CPPFLAGS=$CPPFLAGS
-	CPPFLAGS="-std=c++11 $CPPFLAGS -I/usr/include/catch"
+	CPPFLAGS="-std=c++17 $CPPFLAGS -I/usr/include/catch"
 	AC_LANG_PUSH([C++])
 	AC_CHECK_HEADER([catch.hpp], [], [AC_MSG_FAILURE(catch.hpp not found or not usable. Re-run with --with-bundled-catch to use the bundled library.)])
 	AC_LANG_POP
@@ -383,7 +383,7 @@ AC_SUBST([pegtl_AC_CFLAGS])
 AC_SUBST([pegtl_LIBS])
 
 SAVE_CPPFLAGS=$CPPFLAGS
-CPPFLAGS="-std=c++11 $CPPFLAGS $pegtl_AC_CFLAGS"
+CPPFLAGS="-std=c++17 $CPPFLAGS $pegtl_AC_CFLAGS"
 AC_LANG_PUSH([C++])
 AC_CHECK_HEADER([tao/pegtl.hpp],
 		[AC_DEFINE([HAVE_TAO_PEGTL_HPP], [1], [PEGTL header file with .hpp extension is present])],


### PR DESCRIPTION
Increasing c++ version from 11 to 17 so that we are able to use newer versions of development packages, namely PEGTL 3+.
After investigation, there does not seem to be any compatibility issues.