### PR TITLE
Add treelike list-devices output

### DIFF
--- a/doc/man/usbguard.1.adoc
+++ b/doc/man/usbguard.1.adoc
@@ -81,6 +81,9 @@ Available options:
 *-b, --blocked*::
     List blocked devices.
 
+*-t, --tree*::
+    List devices in a tree format.
+
 *-h, --help*::
     Show help.
 


### PR DESCRIPTION
Now, instead of a list of device rules, you can use list-devices -t and print devices in a nice treelike structure. You can use this option together with either -a or -b option. With -a option, the blocked devices will not be present in a tree and their children will be cut off, similarly as in classical output. With -b option there is no rational way to construct a tree because blocked devices will always be leaves, therefore the tree will have depth 1 and all blocked devices will be printed on one level.

Here is a sample how the treelike output may look like:
![listDevicesTree](https://user-images.githubusercontent.com/17908673/108979691-32d0ab80-768b-11eb-805c-7a9bfeea1efd.png)
