### PR TITLE
Apply PEGTL 3.2.0 fixes to fuzzers.

### DIFF
--- a/src/Tests/Fuzzers/fuzzer-rules.cpp
+++ b/src/Tests/Fuzzers/fuzzer-rules.cpp
@@ -20,7 +20,11 @@
 
 #include <cstdint>
 
+#if TAO_PEGTL_VERSION_MAJOR >= 3
+#include <tao/pegtl/contrib/trace.hpp>
+#else
 #include <tao/pegtl/contrib/tracer.hpp>
+#endif
 #include <usbguard/Rule.hpp>
 #include <usbguard/RuleParser.hpp>
 

--- a/src/Tests/Fuzzers/fuzzer-uevent.cpp
+++ b/src/Tests/Fuzzers/fuzzer-uevent.cpp
@@ -20,7 +20,11 @@
 
 #include <cstdint>
 
+#if TAO_PEGTL_VERSION_MAJOR >= 3
+#include <tao/pegtl/contrib/trace.hpp>
+#else
 #include <tao/pegtl/contrib/tracer.hpp>
+#endif
 #include <UEvent.hpp>
 
 using namespace usbguard;


### PR DESCRIPTION
This fixes the ossfuzz build for usbguard.