### PR TITLE
Add new DevicePolicyApplied signal

### DIFF
--- a/src/CLI/IPCSignalWatcher.cpp
+++ b/src/CLI/IPCSignalWatcher.cpp
@@ -127,6 +127,28 @@ namespace usbguard
     }
   }
 
+  void IPCSignalWatcher::DevicePolicyApplied(uint32_t id,
+    Rule::Target target_new,
+    const std::string& device_rule,
+    uint32_t rule_id)
+  {
+    std::cout << "[device] PolicyApplied: id=" << id << std::endl;
+    std::cout << " target_new=" << Rule::targetToString(target_new) << std::endl;
+    std::cout << " device_rule=" << device_rule << std::endl;
+    std::cout << " rule_id=" << rule_id << std::endl;
+
+    if (hasOpenExecutable()) {
+      const std::map<std::string, std::string> env = {
+        { "USBGUARD_IPC_SIGNAL", "Device.PolicyApplied" },
+        { "USBGUARD_DEVICE_ID", std::to_string(id) },
+        { "USBGUARD_DEVICE_TARGET_NEW", Rule::targetToString(target_new) },
+        { "USBGUARD_DEVICE_RULE", device_rule },
+        { "USBGUARD_DEVICE_RULE_ID", std::to_string(rule_id) }
+      };
+      runExecutable(env);
+    }
+  }
+
   void IPCSignalWatcher::PropertyParameterChanged(const std::string& name,
     const std::string& value_old,
     const std::string& value_new)

--- a/src/CLI/IPCSignalWatcher.hpp
+++ b/src/CLI/IPCSignalWatcher.hpp
@@ -46,6 +46,11 @@ namespace usbguard
       const std::string& device_rule,
       uint32_t rule_id) override;
 
+    void DevicePolicyApplied(uint32_t id,
+      Rule::Target target_new,
+      const std::string& device_rule,
+      uint32_t rule_id) override;
+
     void PropertyParameterChanged(const std::string& name,
       const std::string& value_old,
       const std::string& value_new) override;

--- a/src/DBus/DBusBridge.cpp
+++ b/src/DBus/DBusBridge.cpp
@@ -270,6 +270,27 @@ namespace usbguard
     }
   }
 
+  void DBusBridge::DevicePolicyApplied(uint32_t id,
+    Rule::Target target_new,
+    const std::string& device_rule,
+    uint32_t rule_id)
+  {
+    GVariantBuilder* gv_builder_attributes = deviceRuleToAttributes(device_rule);
+    g_dbus_connection_emit_signal(p_gdbus_connection, nullptr,
+      DBUS_DEVICES_PATH, DBUS_DEVICES_INTERFACE, "DevicePolicyApplied",
+      g_variant_new("(uusua{ss})",
+        id,
+        Rule::targetToInteger(target_new),
+        device_rule.c_str(),
+        rule_id,
+        gv_builder_attributes),
+      nullptr);
+
+    if (gv_builder_attributes != nullptr) {
+      g_variant_builder_unref(gv_builder_attributes);
+    }
+  }
+
   void DBusBridge::PropertyParameterChanged(const std::string& name,
     const std::string& value_old,
     const std::string& value_new)

--- a/src/DBus/DBusBridge.cpp
+++ b/src/DBus/DBusBridge.cpp
@@ -162,6 +162,7 @@ namespace usbguard
   void DBusBridge::handleDevicesMethodCall(const std::string& method_name, GVariant* parameters,
     GDBusMethodInvocation* invocation)
   {
+    USBGUARD_LOG(Debug) << "dbus devices method call: " << method_name;
     if (method_name == "listDevices") {
       const char* query_cstr = nullptr;
       g_variant_get(parameters, "(&s)", &query_cstr);
@@ -199,6 +200,7 @@ namespace usbguard
       uint32_t target_integer = 0;
       gboolean permanent = false;
       g_variant_get(parameters, "(uub)", &device_id, &target_integer, &permanent);
+      USBGUARD_LOG(Debug) << "DBus: applyDevicePolicy: Parsed device_id: " << device_id << " target_integer: " << target_integer << " and permanent: " << permanent;
       const Rule::Target target = Rule::targetFromInteger(target_integer);
       const uint32_t rule_id = applyDevicePolicy(device_id, target, permanent);
       g_dbus_method_invocation_return_value(invocation, g_variant_new("(u)", rule_id));

--- a/src/DBus/DBusBridge.hpp
+++ b/src/DBus/DBusBridge.hpp
@@ -63,6 +63,11 @@ namespace usbguard
       const std::string& device_rule,
       uint32_t rule_id) override;
 
+    void DevicePolicyApplied(uint32_t id,
+      Rule::Target target_new,
+      const std::string& device_rule,
+      uint32_t rule_id) override;
+
     void PropertyParameterChanged(const std::string& name,
       const std::string& value_old,
       const std::string& value_new) override;

--- a/src/DBus/DBusInterface.xml
+++ b/src/DBus/DBusInterface.xml
@@ -152,8 +152,8 @@
       If the permanent flag is set to True, a rule will be appended to the policy or an exiting device
       rule will be modified in order to permanently store the authorization decision.
 
-      Sucessfull exection of this method will cause the DevicePolicyChanged signal to be broadcasted if
-      the device authorization target was different than the applied target.
+      Successful execution of this method will cause the DevicePolicyChanged signal to be broadcasted if
+      the device authorization target was different from the applied target.
       -->
     <method name="applyDevicePolicy">
       <arg name="id" direction="in" type="u"/>
@@ -205,6 +205,7 @@
       DevicePolicyChanged:
        @id: Device id of the device
        @target_old: Previous authorization target in numerical form.
+                    0 = Allow. 1 = Block. 2 = Reject.
        @target_new: Current authorization target in numerical form.
        @device_rule: Device specific rule.
        @rule_id: A rule id of the matched rule. Otherwise a reserved rule id value is used.
@@ -229,6 +230,41 @@
     <signal name="DevicePolicyChanged">
       <arg name="id" direction="out" type="u"/>
       <arg name="target_old" direction="out" type="u"/>
+      <arg name="target_new" direction="out" type="u"/>
+      <arg name="device_rule" direction="out" type="s"/>
+      <arg name="rule_id" direction="out" type="u"/>
+      <arg name="attributes" direction="out" type="a{ss}"/>
+    </signal>
+
+    <!--
+      DevicePolicyApplied:
+       @id: Device id of the device
+       @target_new: Current authorization target in numerical form.
+                    0 = Allow. 1 = Block. 2 = Reject.
+       @device_rule: Device specific rule.
+       @rule_id: A rule id of the matched rule. Otherwise a reserved rule id value is used.
+                 Reserved values are:
+                     4294967294 (UINT32_MAX - 1) for an implicit rule, e.g. 
+                     ImplicitPolicyTarget or InsertedDevicePolicy.
+       @attributes: A dictionary of device attributes and their values.
+
+      Notify about a change of a USB device.
+      This is a superset of DevicePolicyChanged and will always be thrown
+      when a device is inserted, authorised, or rejected.
+
+      The device attribute dictionary contains the following attributes:
+        - id (the USB device ID in the form VID:PID)
+        - name
+        - serial
+        - via-port
+        - hash
+        - parent-hash
+        - with-interface
+        - with-connect-type (either "hardwired", "hotplug", or the empty string for unknown)
+
+     -->
+    <signal name="DevicePolicyApplied">
+      <arg name="id" direction="out" type="u"/>
       <arg name="target_new" direction="out" type="u"/>
       <arg name="device_rule" direction="out" type="s"/>
       <arg name="rule_id" direction="out" type="u"/>

--- a/src/Daemon/Daemon.cpp
+++ b/src/Daemon/Daemon.cpp
@@ -850,6 +850,9 @@ namespace usbguard
         matched_rule->getTarget());
     const bool target_changed = target_old != device_post->getTarget();
 
+    std::shared_ptr<const Rule> device_rule = \
+        device_post->getDeviceRule(/*with_port=*/true,
+          /*with_parent_hash=*/true);
     if (target_changed || matched_rule->getRuleID() == Rule::ImplicitID) {
       if (target_changed) {
         USBGUARD_LOG(Debug) << "Device target changed:"
@@ -860,15 +863,17 @@ namespace usbguard
         USBGUARD_LOG(Debug) << "Implicit rule matched";
       }
 
-      std::shared_ptr<const Rule> device_rule = \
-        device_post->getDeviceRule(/*with_port=*/true,
-          /*with_parent_hash=*/true);
       DevicePolicyChanged(device->getID(),
         target_old,
         device_post->getTarget(),
         device_rule->toString(),
         matched_rule->getRuleID());
     }
+
+    DevicePolicyApplied(device->getID(),
+        device_post->getTarget(),
+        device_rule->toString(),
+        matched_rule->getRuleID());
 
     matched_rule->updateMetaDataCounters(/*applied=*/true);
     audit_event.success();

--- a/src/Library/DeviceManagerPrivate.cpp
+++ b/src/Library/DeviceManagerPrivate.cpp
@@ -117,6 +117,7 @@ namespace usbguard
       return _device_map.at(id);
     }
     catch (...) {
+      USBGUARD_LOG(Debug) << "Lookup error: " << id;
       throw Exception("Device lookup", "device id", "id doesn't exist");
     }
   }

--- a/src/Library/IPC/Devices.proto
+++ b/src/Library/IPC/Devices.proto
@@ -51,6 +51,13 @@ message DevicePolicyChangedSignal {
   required uint32 rule_id = 5;
 }
 
+message DevicePolicyAppliedSignal {
+  required uint32 id = 1;
+  required uint32 target_new = 2;
+  required string device_rule = 3;
+  required uint32 rule_id = 4;
+}
+
 message PropertyParameterChangedSignal {
   required string name = 1;
   required string value_old = 2;

--- a/src/Library/IPCClientPrivate.cpp
+++ b/src/Library/IPCClientPrivate.cpp
@@ -85,6 +85,7 @@ namespace usbguard
     registerHandler<IPC::Exception>(&IPCClientPrivate::handleException);
     registerHandler<IPC::DevicePresenceChangedSignal>(&IPCClientPrivate::handleDevicePresenceChangedSignal);
     registerHandler<IPC::DevicePolicyChangedSignal>(&IPCClientPrivate::handleDevicePolicyChangedSignal);
+    registerHandler<IPC::DevicePolicyAppliedSignal>(&IPCClientPrivate::handleDevicePolicyAppliedSignal);
     registerHandler<IPC::PropertyParameterChangedSignal>(&IPCClientPrivate::handlePropertyParameterChangedSignal);
 
     if (connected) {
@@ -517,6 +518,17 @@ namespace usbguard
       reinterpret_cast<const IPC::DevicePolicyChangedSignal*>(message_in.get());
     _p_instance.DevicePolicyChanged(signal->id(),
       Rule::targetFromInteger(signal->target_old()),
+      Rule::targetFromInteger(signal->target_new()),
+      signal->device_rule(),
+      signal->rule_id());
+  }
+
+  void IPCClientPrivate::handleDevicePolicyAppliedSignal(IPC::MessagePointer& message_in, IPC::MessagePointer& message_out)
+  {
+    (void)message_out;
+    const IPC::DevicePolicyAppliedSignal* const signal = \
+      reinterpret_cast<const IPC::DevicePolicyAppliedSignal*>(message_in.get());
+    _p_instance.DevicePolicyApplied(signal->id(),
       Rule::targetFromInteger(signal->target_new()),
       signal->device_rule(),
       signal->rule_id());

--- a/src/Library/IPCClientPrivate.hpp
+++ b/src/Library/IPCClientPrivate.hpp
@@ -109,6 +109,7 @@ namespace usbguard
     void handleException(IPC::MessagePointer& message_in, IPC::MessagePointer& message_out);
     void handleDevicePresenceChangedSignal(IPC::MessagePointer& message_in, IPC::MessagePointer& message_out);
     void handleDevicePolicyChangedSignal(IPC::MessagePointer& message_in, IPC::MessagePointer& message_out);
+    void handleDevicePolicyAppliedSignal(IPC::MessagePointer& message_in, IPC::MessagePointer& message_out);
     void handlePropertyParameterChangedSignal(IPC::MessagePointer& message_in, IPC::MessagePointer& message_out);
 
     IPCClient& _p_instance;

--- a/src/Library/IPCPrivate.cpp
+++ b/src/Library/IPCPrivate.cpp
@@ -38,14 +38,15 @@ namespace usbguard
     { 0x02, "usbguard.IPC.applyDevicePolicy" },
     { 0x03, "usbguard.IPC.DevicePresenceChangedSignal" },
     { 0x04, "usbguard.IPC.DevicePolicyChangedSignal" },
-    { 0x05, "usbguard.IPC.PropertyParameterChangedSignal" },
-    { 0x06, "usbguard.IPC.listRules" },
-    { 0x07, "usbguard.IPC.appendRule" },
-    { 0x08, "usbguard.IPC.removeRule" },
-    { 0x09, "usbguard.IPC.Exception" },
-    { 0x0a, "usbguard.IPC.getParameter" },
-    { 0x0b, "usbguard.IPC.setParameter" },
-    { 0x0c, "usbguard.IPC.checkIPCPermissions" }
+    { 0x05, "usbguard.IPC.DevicePolicyAppliedSignal" },
+    { 0x06, "usbguard.IPC.PropertyParameterChangedSignal" },
+    { 0x07, "usbguard.IPC.listRules" },
+    { 0x08, "usbguard.IPC.appendRule" },
+    { 0x09, "usbguard.IPC.removeRule" },
+    { 0x0a, "usbguard.IPC.Exception" },
+    { 0x0b, "usbguard.IPC.getParameter" },
+    { 0x0c, "usbguard.IPC.setParameter" },
+    { 0x0d, "usbguard.IPC.checkIPCPermissions" }
   };
 
   uint32_t IPC::messageTypeNameToNumber(const std::string& name)

--- a/src/Library/IPCServerPrivate.cpp
+++ b/src/Library/IPCServerPrivate.cpp
@@ -535,6 +535,10 @@ namespace usbguard
       return IPCServer::AccessControl::Section::DEVICES;
     }
 
+    if (name == "usbguard.IPC.DevicePolicyAppliedSignal") {
+      return IPCServer::AccessControl::Section::DEVICES;
+    }
+
     if (name == "usbguard.IPC.PropertyParameterChangedSignal") {
       return IPCServer::AccessControl::Section::PARAMETERS;
     }
@@ -1030,6 +1034,19 @@ namespace usbguard
     IPC::DevicePolicyChangedSignal signal;
     signal.set_id(id);
     signal.set_target_old(Rule::targetToInteger(target_old));
+    signal.set_target_new(Rule::targetToInteger(target_new));
+    signal.set_device_rule(device_rule);
+    signal.set_rule_id(rule_id);
+    qbIPCBroadcastMessage(&signal);
+  }
+
+  void IPCServerPrivate::DevicePolicyApplied(uint32_t id,
+    Rule::Target target_new,
+    const std::string& device_rule,
+    uint32_t rule_id)
+  {
+    IPC::DevicePolicyAppliedSignal signal;
+    signal.set_id(id);
     signal.set_target_new(Rule::targetToInteger(target_new));
     signal.set_device_rule(device_rule);
     signal.set_rule_id(rule_id);

--- a/src/Library/IPCServerPrivate.hpp
+++ b/src/Library/IPCServerPrivate.hpp
@@ -63,6 +63,11 @@ namespace usbguard
       const std::string& device_rule,
       uint32_t rule_id);
 
+    void DevicePolicyApplied(uint32_t id,
+      Rule::Target target_new,
+      const std::string& device_rule,
+      uint32_t rule_id);
+
     void PropertyParameterChanged(const std::string& name,
       const std::string& value_old,
       const std::string& value_new);

--- a/src/Library/public/usbguard/IPCClient.hpp
+++ b/src/Library/public/usbguard/IPCClient.hpp
@@ -223,6 +223,24 @@ namespace usbguard
     }
 
     /**
+     * @brief Defines actions to perform when a USB device
+     * has been inserted, accepted, or rejected.
+     *
+     * @see \link Interface::DevicePolicyApplied()
+     * DevicePolicyApplied()\endlink
+     */
+    virtual void DevicePolicyApplied(uint32_t id,
+      Rule::Target target_new,
+      const std::string& device_rule,
+      uint32_t rule_id) override
+    {
+      (void)id;
+      (void)target_new;
+      (void)device_rule;
+      (void)rule_id;
+    }
+
+    /**
      * @brief Defines algorithm to perform in the case that property parameter
      * has been changed.
      *

--- a/src/Library/public/usbguard/IPCServer.cpp
+++ b/src/Library/public/usbguard/IPCServer.cpp
@@ -286,6 +286,14 @@ namespace usbguard
     d_pointer->DevicePolicyChanged(id, target_old, target_new, device_rule, rule_id);
   }
 
+  void IPCServer::DevicePolicyApplied(uint32_t id,
+    Rule::Target target_new,
+    const std::string& device_rule,
+    uint32_t rule_id)
+  {
+    d_pointer->DevicePolicyApplied(id, target_new, device_rule, rule_id);
+  }
+
   void IPCServer::PropertyParameterChanged(const std::string& name,
     const std::string& value_old,
     const std::string& value_new)

--- a/src/Library/public/usbguard/IPCServer.hpp
+++ b/src/Library/public/usbguard/IPCServer.hpp
@@ -324,6 +324,14 @@ namespace usbguard
       uint32_t rule_id);
 
     /**
+     * @copydoc Interface::DevicePolicyApplied()
+     */
+    void DevicePolicyApplied(uint32_t id,
+      Rule::Target target_new,
+      const std::string& device_rule,
+      uint32_t rule_id);
+
+    /**
      * @copydoc Interface::PropertyParameterChanged()
      */
     void PropertyParameterChanged(const std::string& name,

--- a/src/Library/public/usbguard/Interface.hpp
+++ b/src/Library/public/usbguard/Interface.hpp
@@ -190,6 +190,32 @@ namespace usbguard
       uint32_t rule_id) = 0;
 
     /**
+     * @brief Notify about the acceptance or rejection of a device.
+     *
+     * This signal is thrown whenever a device is inserted.
+     * It is also thrown when a device has been allowed or rejected.
+     *
+     * The device attribute dictionary contains the following attributes:
+     * - id (the USB device ID in the form VID:PID)
+     * - name
+     * - serial
+     * - via-port
+     * - hash
+     * - parent-hash
+     * - with-interface
+     *
+     * @param id ID of the device.
+     * @param target_new Current authorization target.
+     * @param device_rule Device specific rule.
+     * @param rule_id Rule ID of the matched rule.
+     * Otherwise a reserved rule ID value is used.
+     */
+    virtual void DevicePolicyApplied(uint32_t id,
+      Rule::Target target_new,
+      const std::string& device_rule,
+      uint32_t rule_id) = 0;
+
+    /**
      * @brief Notify about a change of a property parameter.
      *
      * @param name Policy name.

--- a/src/Library/public/usbguard/RuleSet.cpp
+++ b/src/Library/public/usbguard/RuleSet.cpp
@@ -72,6 +72,7 @@ namespace usbguard
   uint32_t RuleSet::appendRule(const Rule& rule, uint32_t parent_id, bool lock)
   {
     std::unique_lock<std::mutex> op_lock(_op_mutex, std::defer_lock);
+    USBGUARD_LOG(Debug) << "appendRule parent:" << parent_id;
 
     if (lock) {
       op_lock.lock();


### PR DESCRIPTION
The intention is to fix https://github.com/USBGuard/usbguard/issues/353, e.g. have a reliable signal to know what has happened to a device. This is the hard way of what I described [here](https://github.com/USBGuard/usbguard/pull/385#issue-424670552), i.e. a new signal rather than changing existing behaviour.

If this is acceptable, I may be working on docs. But since it's unclear to me that this is an acceptable change, I haven't taken the time for writing docs, yet.

For now, this is WIP, because of the commits enabling the logging. Also, I had a silly mistake when defining the new signal. Fortunately, @RyuzakiKK beat me to it. I will, if this is an acceptable change, separate the logging and squash commits.

@radosroka WDYT?