### PR TITLE
Add CAP_AUDIT_WRITE capability to service file

### DIFF
--- a/usbguard.service.in
+++ b/usbguard.service.in
@@ -5,7 +5,7 @@ Documentation=man:usbguard-daemon(8)
 
 [Service]
 AmbientCapabilities=
-CapabilityBoundingSet=CAP_CHOWN CAP_FOWNER
+CapabilityBoundingSet=CAP_CHOWN CAP_FOWNER CAP_AUDIT_WRITE
 DevicePolicy=closed
 ExecStart=%sbindir%/usbguard-daemon -f -s -c %sysconfdir%/usbguard/usbguard-daemon.conf
 IPAddressDeny=any


### PR DESCRIPTION
Add CAP_AUDIT_WRITE capability to ```usbguard.service.in ``` file.
It must be specified, otherwise LinuxAudit won't work as AuditBackend.