### PR TITLE
Refactoring - remove unused variable and dead code

### DIFF
--- a/src/Library/DeviceBase.cpp
+++ b/src/Library/DeviceBase.cpp
@@ -98,10 +98,6 @@ namespace usbguard
      *
      */
     FDInputStream descriptor_stream(sysfs_device.openAttribute("descriptors"));
-    /*
-     * Find out the descriptor data stream size
-     */
-    size_t descriptor_expected_size = 0;
 
     if (!descriptor_stream.good()) {
       throw ErrnoException("DeviceBase", sysfs_device.getPath(), errno);
@@ -110,7 +106,7 @@ namespace usbguard
     initializeHash();
     USBDescriptorParser parser(*this);
 
-    if ((descriptor_expected_size = parser.parse(descriptor_stream)) < sizeof(USBDeviceDescriptor)) {
+    if (parser.parse(descriptor_stream) < sizeof(USBDeviceDescriptor)) {
       throw Exception("DeviceBase", sysfs_device.getPath(),
         "USB descriptor parser processed less data than the size of a USB device descriptor");
     }

--- a/src/Library/DeviceManagerBase.cpp
+++ b/src/Library/DeviceManagerBase.cpp
@@ -149,8 +149,6 @@ namespace usbguard
     }
 
 #endif
-    /* UNREACHABLE */
-    return std::string();
   }
 
   int DeviceManagerBase::ueventOpen()


### PR DESCRIPTION
Fix warnings detected by static analysis

### Error: CLANG_WARNING: [#def1]
`usbguard-1.0.0/src/Library/DeviceBase.cpp:113:10`: warning[deadcode.**DeadStores**]: Although the value stored to ```descriptor_expected_size``` is used in the enclosing expression, the value is never actually read from ```descriptor_expected_size```
```
111|       USBDescriptorParser parser(*this);
112|   
113|->     if ((descriptor_expected_size = parser.parse(descriptor_stream)) < sizeof(USBDeviceDescriptor)) {
114|         throw Exception("DeviceBase", sysfs_device.getPath(),
115|           "USB descriptor parser processed less data than the size of a USB device descriptor");
```

### Error: UNREACHABLE (CWE-561): [#def2]
`usbguard-1.0.0/src/Library/DeviceManagerBase.cpp:153`: **unreachable**: This code cannot be reached: `return std::__cxx11::string();`.
```
151|   #endif
152|       /* UNREACHABLE */
153|->     return std::string();
154|     }
155|
```
