### PR TITLE
Add #include <tao/pegtl.hpp> to fuzzers.

### DIFF
--- a/src/Tests/Fuzzers/fuzzer-rules.cpp
+++ b/src/Tests/Fuzzers/fuzzer-rules.cpp
@@ -20,6 +20,7 @@
 
 #include <cstdint>
 
+#include <tao/pegtl.hpp>
 #if TAO_PEGTL_VERSION_MAJOR >= 3
 #include <tao/pegtl/contrib/trace.hpp>
 #else

--- a/src/Tests/Fuzzers/fuzzer-uevent.cpp
+++ b/src/Tests/Fuzzers/fuzzer-uevent.cpp
@@ -20,6 +20,7 @@
 
 #include <cstdint>
 
+#include <tao/pegtl.hpp>
 #if TAO_PEGTL_VERSION_MAJOR >= 3
 #include <tao/pegtl/contrib/trace.hpp>
 #else


### PR DESCRIPTION
tao/pegtl.hpp includes version.hpp which defines
TAO_PEGTL_VERSION_MAJOR. This is needed for #458 to work as intended.