### PR TITLE
Improve group/user name checking

### DIFF
--- a/src/Common/Utility.cpp
+++ b/src/Common/Utility.cpp
@@ -542,6 +542,32 @@ namespace usbguard
     std::sort(rulefile_list.begin(), rulefile_list.end());
     return rulefile_list;
   }
+
+  bool isValidName(const std::string& name)
+  {
+    const char* s = name.data();
+
+    if (('\0' == *s) ||
+      !((('a' <= *s) && ('z' >= *s)) ||
+        (('A' <= *s) && ('Z' >= *s)) ||
+        ('_' == *s))) {
+      return false;
+    }
+
+    while ('\0' != *++s) {
+      if (!((('a' <= *s) && ('z' >= *s)) ||
+          (('A' <= *s) && ('Z' >= *s)) ||
+          (('0' <= *s) && ('9' >= *s)) ||
+          ('_' == *s) ||
+          ('-' == *s) ||
+          (('$' == *s) && ('\0' == *(s + 1))))) {
+        return false;
+      }
+    }
+
+    return true;
+  }
+
 } /* namespace usbguard */
 
 /* vim: set ts=2 sw=2 et */

--- a/src/Common/Utility.hpp
+++ b/src/Common/Utility.hpp
@@ -316,6 +316,15 @@ namespace usbguard
     return ss.str();
   }
 
+  /**
+   * @brief Checks whether a given name is a valid group/user name
+   *
+   * User/group names must match [A-Za-z_][A-Za-z0-9_-]*[$]
+   *
+   * @param name Name to check
+   * @return True if given name is valid, false otherwise
+   */
+  bool isValidName(const std::string& name);
 
 } /* namespace usbguard */
 

--- a/src/Library/public/usbguard/IPCServer.cpp
+++ b/src/Library/public/usbguard/IPCServer.cpp
@@ -36,10 +36,8 @@ namespace usbguard
       throw Exception("IPC access control", "name too long", name);
     }
 
-    const std::string valid_chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789_";
-
-    if (name.find_first_not_of(valid_chars) != std::string::npos) {
-      throw Exception("IPC access control", "name contains invalid character(s)", name);
+    if (!isValidName(name)) {
+      throw Exception("IPC access control", "invalid name format", name);
     }
   }
 

--- a/src/Library/public/usbguard/IPCServer.hpp
+++ b/src/Library/public/usbguard/IPCServer.hpp
@@ -50,9 +50,9 @@ namespace usbguard
     /**
      * @brief Checks whether given name is a valid access control name.
      *
-     * Name is a valid access control name if and only if:
-     *  1. name is not longer then 32 characters.
-     *  2. name consists only from characters from set { A-Z, a-z, 0-9, _ }.
+     * Name is a valid access control name iff:
+     *  1. it is not longer then 32 characters
+     *  2. it matches regex [A-Za-z_][A-Za-z0-9_-]*[$]
      *
      * @param name Name to be verified.
      * @throw Exception If \p name is not a valid access control name.


### PR DESCRIPTION
Make name checking consistent with **useradd** manual page definition (with addition of capital letters).

Resolves #478