### PR TITLE
Exception.hpp: fix build on musl

### DIFF
--- a/src/Library/public/usbguard/Exception.hpp
+++ b/src/Library/public/usbguard/Exception.hpp
@@ -126,7 +126,8 @@ namespace usbguard
     static std::string reasonFromErrno(const int errno_value)
     {
       char buffer[1024];
-      return std::string(strerror_r(errno_value, buffer, sizeof buffer));
+      strerror_r(errno_value, buffer, sizeof buffer);
+      return std::string(buffer);
     }
   };
 


### PR DESCRIPTION
Fix the following build failure on musl:

```
In file included from ./src/Library/public/usbguard/Rule.hpp:24,
                 from src/CLI/usbguard-rule-parser.cpp:23:
./src/Library/public/usbguard/Exception.hpp: In static member function 'static std::string usbguard::ErrnoException::reasonFromErrno(int)':
./src/Library/public/usbguard/Exception.hpp:129:72: error: no matching function for call to 'std::__cxx11::basic_string<char>::basic_string(int)'
  129 |       return std::string(strerror_r(errno_value, buffer, sizeof buffer));
      |
```

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>