### PR TITLE
Update docs

### DIFF
--- a/doc/man/usbguard-daemon.conf.5.adoc
+++ b/doc/man/usbguard-daemon.conf.5.adoc
@@ -162,6 +162,8 @@ Available sections and privileges:
 
  ** list: Get values of run-time parameters.
 
+ ** listen: Listen to property parameter changes.
+
 The following is a generally usable and reasonably safe example of an access control file.
 It allows one to modify USB device authorization state (`Devices=modify`), list USB devices (`Devices=list`), listen to USB device related events (`Devices=listen`), list USB authorization policy rules (`Policy=list`) and listen to exception events (`Exceptions=listen`):
 

--- a/doc/man/usbguard.1.adoc
+++ b/doc/man/usbguard.1.adoc
@@ -285,6 +285,7 @@ The 'privileges' are expected to be in the form of a list separated by a colon:
 ....
 
 Consult the usbguard-daemon.conf(5) man-page for a detailed list of available privileges in each section.
+You can also use 'ALL' instead of 'privileges' to automatically assign all relevant privileges to a given section.
 
 
 === *remove-user* 'name' ['OPTIONS']


### PR DESCRIPTION
* add privilege "listen" for section "Parameters" into documentation
* add "ALL" as a valid substitution for privileges in usbguard add-user command