### PR TITLE
Validate ACL permission existence

### DIFF
--- a/src/Library/public/usbguard/IPCServer.hpp
+++ b/src/Library/public/usbguard/IPCServer.hpp
@@ -278,6 +278,17 @@ namespace usbguard
       };
 
       /**
+       * @brief Get a privilege mask for given section
+       *
+       * For example, if the section is POLICY that has privileges MODIFY
+       * and LIST, the mask would be ~(MODIFY | LIST)
+       *
+       * @param section Section for which the privilege mask should be returned
+       * @return Privilege mask for section
+       */
+      uint8_t ac_mask(Section section) const;
+
+      /**
        * @brief Access control represented by unordered map of
        * tuples (Section, 8b privileges).
        *


### PR DESCRIPTION
Fail when a valid privilege string is given to a section that does not define behaviour for such privilege.
Example: usbguard add-user testuser -p listen
Privilege listen is irrelevant for section Policy and this call should fail.