### PR TITLE
Indicate root cause of the error when seccomp/libcap-ng is requested but not available

### DIFF
--- a/src/Daemon/main.cpp
+++ b/src/Daemon/main.cpp
@@ -161,15 +161,22 @@ int main(int argc, char* argv[])
 
   /* Setup seccomp allowlist & drop capabilities */
   if (use_seccomp_allowlist) {
+#if defined(HAVE_SECCOMP)
     if (!setupSeccompWhitelist()) {
+      USBGUARD_LOG(Error) << "Unable to setup seccomp";
       return EXIT_FAILURE;
     }
+#else
+    USBGUARD_LOG(Error) << "USBGuard was not compiled with libseccomp support";
+    return EXIT_FAILURE;
+#endif
   }
 
   if (drop_capabilities) {
 #if defined(HAVE_LIBCAPNG)
     setupCapabilities();
 #else
+    USBGUARD_LOG(Error) << "USBGuard was not compiled with libcap-ng support";
     return EXIT_FAILURE;
 #endif
   }


### PR DESCRIPTION
Closes #494