### PR TITLE
enhance the fix of race condition while reading connect_type

### DIFF
--- a/src/Tests/UseCase/003_cli_devices_umockdev.sh
+++ b/src/Tests/UseCase/003_cli_devices_umockdev.sh
@@ -53,6 +53,7 @@ function test_cli_devices()
 
   ${USBGUARD} block-device "$id_dock"
   ${USBGUARD} allow-device "$id_dock"
+  sleep 1
 
   local id_dock_child="$(${USBGUARD} list-devices | sed -n 's|^\([0-9]\+\):.*hash "D3deklX12Ir3kJPfUZ5AQNwHeZn1bwtPkQkw6e+8B38=".*$|\1|p')"
   
@@ -64,6 +65,7 @@ function test_cli_devices()
   ${USBGUARD} block-device "$id_dock_child"
   ${USBGUARD} block-device "$id_dock"
   ${USBGUARD} allow-device "$id_dock"
+  sleep 1
 
   local id_dock_child="$(${USBGUARD} list-devices | sed -n 's|^\([0-9]\+\):.*hash "D3deklX12Ir3kJPfUZ5AQNwHeZn1bwtPkQkw6e+8B38=".*$|\1|p')"
   

--- a/src/Tests/UseCase/003_cli_devices_umockdev.sh
+++ b/src/Tests/UseCase/003_cli_devices_umockdev.sh
@@ -46,7 +46,7 @@ function test_cli_devices()
   local id_dock="$(${USBGUARD} list-devices | sed -n 's|^\([0-9]\+\):.*hash "2y2qS3rcuMr1Ye5knWsbD8CGzPtrs+eiRR/haro7+Ng=".*$|\1|p')"
 
   if [ -z "$id_dock" ]; then
-    echo "Test error: Unable to parse device ID"
+    echo "Test error: Unable to parse device ID (test line ${LINENO})"
     exit 1
   fi
 
@@ -57,7 +57,7 @@ function test_cli_devices()
   local id_dock_child="$(${USBGUARD} list-devices | sed -n 's|^\([0-9]\+\):.*hash "D3deklX12Ir3kJPfUZ5AQNwHeZn1bwtPkQkw6e+8B38=".*$|\1|p')"
   
   if [ -z "$id_dock_child" ]; then
-    echo "Test error: Unable to parse device ID"
+    echo "Test error: Unable to parse device ID (test line ${LINENO})"
     exit 1
   fi
 
@@ -68,7 +68,7 @@ function test_cli_devices()
   local id_dock_child="$(${USBGUARD} list-devices | sed -n 's|^\([0-9]\+\):.*hash "D3deklX12Ir3kJPfUZ5AQNwHeZn1bwtPkQkw6e+8B38=".*$|\1|p')"
   
   if [ -z "$id_dock_child" ]; then
-    echo "Test error: Unable to parse device ID"
+    echo "Test error: Unable to parse device ID (test line ${LINENO})"
     exit 1
   fi
 


### PR DESCRIPTION
Fixes #493 - Hardware and Kernel timings varies on different devices
and while-loop alone doesn't provide considerable delay.
Add small delay in between retry attempts

Host controllers doesn't have port/connect_type
Daemon waits for the entire loop time to return an empty
value. Filter the host controllers and return an empty
string without going through the loop