### PR TITLE
Actions: Replace missing matrix variable "config.make_args" by "-j$(nproc)"

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -117,7 +117,7 @@ jobs:
         ./autogen.sh
         mkdir build && cd build
         CC=${{ matrix.config.cc }} CXX=${{ matrix.config.cxx }} ../configure --enable-werror --disable-silent-rules --with-bundled-catch --with-bundled-pegtl --with-ldap --enable-full-test-suite ${{ matrix.config.configure_args }}
-        make ${{ matrix.config.make_args }}
+        make "-j$(nproc)"
 
     - name: check
       run: cd build && sudo make check


### PR DESCRIPTION
Looking at commit 498076c49ff7afb5fe034880903972612e09005a you'll find that there has never been a variable `make_args`:

```console
# git show 498076c4 | fgrep make_args
+        make ${{ matrix.config.make_args }}
```