### PR TITLE
configure.ac: Drop use of missing variable ${have_pegtl_lte_320}

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -764,7 +764,7 @@ echo " libseccomp: $libseccomp_summary"
 echo "  libcap-ng: $libcap_ng_summary"
 echo "   protobuf: $protobuf_summary"
 echo "      Catch: $catch_summary"
-echo "      PEGTL: $pegtl_summary; version <= 3.2.0: $have_pegtl_lte_320"
+echo "      PEGTL: $pegtl_summary"
 echo "      GDBus: $dbus_summary"
 echo "   umockdev: $umockdev_summary"
 echo


### PR DESCRIPTION
There is no variable `${have_pegtl_lte_320}` as of today, deleting its reference fixes  `./configure` output.

<details>
<summary>Here's how that variable became missing: (click to expand)</summary>

- Use of variable `have_pegtl_lte_320` was born from `have_pegtl_lte_260` in commit 4bf21aedcb260314996f0fa521ef4a3a6ae4a2bb.
- Use of variable `have_pegtl_lte_260` was born from `have_pegtl_lte_131` in commit 5fc0685e0795b98b0c1941346b036891e0136398.
- The definition of `have_pegtl_lte_131` has been removed without replacement in commit 78af3315d044a1db56a34ab3a84dc0d87101704b though.
- Hence there is nothing defining variable `have_pegtl_lte_320` today.

For proof from Git history:

```console
# git log -p | grep '^commit\|^[+-].*have_pegtl_lte_' | fgrep -B1 have_pegtl_lte_
commit 4bf21aedcb260314996f0fa521ef4a3a6ae4a2bb
-echo "      PEGTL: $pegtl_summary; version <= 2.6.0: $have_pegtl_lte_260"
+echo "      PEGTL: $pegtl_summary; version <= 3.2.0: $have_pegtl_lte_320"
--
commit 5fc0685e0795b98b0c1941346b036891e0136398
-echo "      PEGTL: $pegtl_summary; version <= 1.3.1: $have_pegtl_lte_131"
+echo "      PEGTL: $pegtl_summary; version <= 2.6.0: $have_pegtl_lte_260"
--
commit 78af3315d044a1db56a34ab3a84dc0d87101704b
-[have_pegtl_lte_131=no], [have_pegtl_lte_131=yes])
-if test "x$have_pegtl_lte_131" = xyes; then
--
commit 630bdded4ba99126340424c94193c036cf5e552e
+[have_pegtl_lte_131=no], [have_pegtl_lte_131=yes])
+if test "x$have_pegtl_lte_131" = xyes; then
+echo "      PEGTL: $pegtl_summary; version <= 1.3.1: $have_pegtl_lte_131"
```
</details>