### PR TITLE
Exception.hpp: Fix use of strerror_r for XSI-compliant version (e.g. with musl) (alternative to #481)

### DIFF
--- a/src/Library/public/usbguard/Exception.hpp
+++ b/src/Library/public/usbguard/Exception.hpp
@@ -125,8 +125,17 @@ namespace usbguard
   private:
     static std::string reasonFromErrno(const int errno_value)
     {
-      char buffer[1024];
-      return std::string(strerror_r(errno_value, buffer, sizeof buffer));
+      char buffer[1024] = "Unknown error";
+      const char* error_message = buffer;
+      // See "man strerror_r" for why we need these two cases:
+#if defined(_POSIX_C_SOURCE) && (_POSIX_C_SOURCE >= 200112L) && ! defined(_GNU_SOURCE)
+      // We have the XSI-compliant version of strerror_r with int return
+      strerror_r(errno_value, buffer, sizeof buffer);
+#else
+      // We have the GNU-specific version of strerror_r with char* return
+      error_message = strerror_r(errno_value, buffer, sizeof buffer);
+#endif
+      return std::string(error_message);
     }
   };
 


### PR DESCRIPTION
Alternative to incomplete PR #481.

References:
- `man strerror_r` (excerpts inline below)
- [musl strerror_r.c](https://git.musl-libc.org/cgit/musl/tree/src/string/strerror_r.c)

The relevant parts from the man page are these:

1.
> ```        
>        int strerror_r(int errnum, char *buf, size_t buflen);
>                       /* XSI-compliant */
> 
>        char *strerror_r(int errnum, char *buf, size_t buflen);
>                       /* GNU-specific */
> ```
2.
> ```
>        strerror_r():
>            The XSI-compliant version is provided if:
>                (_POSIX_C_SOURCE >= 200112L) && ! _GNU_SOURCE
>            Otherwise, the GNU-specific version is provided.
> ```
3. 
> ```
>        The XSI-compliant strerror_r() is preferred for portable applications.
>        It returns the error string in the user-supplied buffer buf of length
>        buflen.
>  
>        The GNU-specific strerror_r() returns a pointer to a string containing
>        the error message.  This may be either a pointer to a string that the
>        function stores in buf, or a pointer to  some (immutable) static string
>        (in which case buf is unused).  If the function stores a string in buf,
>        then at most buflen bytes are stored (the string may be truncated if
>        buflen is too small and errnum is unknown).  The string always includes
>        a terminating null byte ('\0').
> ```
