### PR TITLE
Fix compilation with musl + make GitHub Actions protect against future musl regressions

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -26,6 +26,7 @@ jobs:
       fail-fast: false
       matrix:
         linux_distro:
+        - Alpine Linux 3.15  # with musl
         - CentOS 8.2         # with GCC 8.5.0
 
     name: Build on ${{ matrix.linux_distro }} using Docker

--- a/configure.ac
+++ b/configure.ac
@@ -573,6 +573,9 @@ if test "x$enable_asan" = xyes; then
   AX_CHECK_COMPILE_FLAG([-fno-omit-frame-pointer],
                         [ASAN_FLAGS="$ASAN_FLAGS -fno-omit-frame-pointer"],
                         [], [])
+  AX_CHECK_COMPILE_FLAG([-static-libasan],
+                        [ASAN_FLAGS="$ASAN_FLAGS -static-libasan"],
+                        [], [])
   AC_LANG_POP
 fi
 #

--- a/configure.ac
+++ b/configure.ac
@@ -174,6 +174,29 @@ AS_IF([test "x${have_gnu_basename}" = xyes], [
   AC_DEFINE([HAVE_GNU_BASENAME], [1], [Wether the GNU version of function basename(3) is available (or just the POSIX one).])
 ], [])
 
+# GNU or XSI strerror_r(3) function?
+AC_MSG_CHECKING([for strerror_r function])
+AC_LANG_PUSH([C++])
+AC_COMPILE_IFELSE([AC_LANG_SOURCE([
+    #undef _POSIX_C_SOURCE
+    #define _GNU_SOURCE
+    #include <cstring>
+    int main(int argc, char ** argv) {
+        char * res = ::strerror_r(0, 0, 0);
+        return 0;
+    }
+])], [
+    have_gnu_strerror_r=yes
+    AC_MSG_RESULT([GNU])
+], [
+    have_gnu_strerror_r=no
+    AC_MSG_RESULT([XSI])
+])
+AC_LANG_POP()
+AS_IF([test "x${have_gnu_strerror_r}" = xyes], [
+  AC_DEFINE([HAVE_GNU_STRERROR_R], [1], [Wether the GNU version of function strerror_r(3) is available (or just the XSI one).])
+], [])
+
 #
 # Checks for required libraries.
 #

--- a/configure.ac
+++ b/configure.ac
@@ -152,6 +152,28 @@ AC_CHECK_LIB([atomic], [__atomic_add_fetch_8], [
 ], [atomic_LIBS=""])
 AC_SUBST([atomic_LIBS])
 
+# GNU (or just POSIX) basename(3) function?
+AC_MSG_CHECKING([for basename function])
+AC_LANG_PUSH([C++])
+AC_COMPILE_IFELSE([AC_LANG_SOURCE([
+    #define _GNU_SOURCE
+    #include <cstring>
+    int main(int argc, char ** argv) {
+        ::basename(*argv);
+        return 0;
+    }
+])], [
+    have_gnu_basename=yes
+    AC_MSG_RESULT([GNU])
+], [
+    have_gnu_basename=no
+    AC_MSG_RESULT([POSIX])
+])
+AC_LANG_POP()
+AS_IF([test "x${have_gnu_basename}" = xyes], [
+  AC_DEFINE([HAVE_GNU_BASENAME], [1], [Wether the GNU version of function basename(3) is available (or just the POSIX one).])
+], [])
+
 #
 # Checks for required libraries.
 #

--- a/scripts/docker/build_on_alpine_linux_3_15.Dockerfile
+++ b/scripts/docker/build_on_alpine_linux_3_15.Dockerfile
@@ -1,0 +1,42 @@
+##
+## Copyright (c) 2022 Sebastian Pipping <sebastian@pipping.org>
+##
+## This program is free software; you can redistribute it and/or modify
+## it under the terms of the GNU General Public License as published by
+## the Free Software Foundation; either version 2 of the License, or
+## (at your option) any later version.
+##
+## This program is distributed in the hope that it will be useful,
+## but WITHOUT ANY WARRANTY; without even the implied warranty of
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+## GNU General Public License for more details.
+##
+## You should have received a copy of the GNU General Public License
+## along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+FROM alpine:3.15
+RUN echo '@edge-testing https://dl-cdn.alpinelinux.org/alpine/edge/testing' >> /etc/apk/repositories \
+        && \
+    apk add --update \
+            autoconf \
+            automake \
+            dbus-glib-dev \
+            file \
+            g++ \
+            gcc \
+            git \
+            libgcrypt-dev \
+            libqb-dev@edge-testing \
+            libsodium-dev \
+            libtool \
+            make \
+            musl-dev \
+            pegtl@edge-testing \
+            pkgconf \
+            polkit-dev \
+            protobuf-dev
+ADD usbguard.tar usbguard/
+WORKDIR usbguard
+RUN git init &>/dev/null && ./autogen.sh
+RUN ./configure --with-bundled-catch || ! cat config.log
+RUN make V=1 "-j$(nproc)"

--- a/src/CLI/usbguard-rule-parser.cpp
+++ b/src/CLI/usbguard-rule-parser.cpp
@@ -23,11 +23,20 @@
 #include "usbguard/Rule.hpp"
 #include "usbguard/RuleParser.hpp"
 
-#include <iostream>
-#ifndef _GNU_SOURCE
-  #define _GNU_SOURCE
+#ifdef HAVE_GNU_BASENAME
+  /* GNU version of basename(3) */
+  #ifndef _GNU_SOURCE
+    #define _GNU_SOURCE
+  #endif
+  #include <cstring>
+#else
+  /* POSIX version of basename(3) */
+  #include <libgen.h>
 #endif
-#include <cstring>
+
+#include <cstdlib>  // for free(3)
+#include <cstring>  // for strdup(3)
+#include <iostream>
 #include <fstream>
 
 #include <getopt.h>
@@ -43,14 +52,16 @@ static const struct ::option options_long[] = {
 
 static void showHelp(std::ostream& stream, const char* usbguard_arg0)
 {
-  stream << " Usage: " << ::basename(usbguard_arg0) << " [OPTIONS] <rule_spec>" << std::endl;
-  stream << " Usage: " << ::basename(usbguard_arg0) << " [OPTIONS] -f <file>" << std::endl;
+  char* const writeable_arg0 = ::strdup(usbguard_arg0);
+  stream << " Usage: " << ::basename(writeable_arg0) << " [OPTIONS] <rule_spec>" << std::endl;
+  stream << " Usage: " << ::basename(writeable_arg0) << " [OPTIONS] -f <file>" << std::endl;
   stream << std::endl;
   stream << " Options:" << std::endl;
   stream << "  -f, --file       Interpret the argument as a path to a file that should be parsed." << std::endl;
   stream << "  -t, --trace      Enable parser tracing." << std::endl;
   stream << "  -h, --help       Show this help." << std::endl;
   stream << std::endl;
+  ::free(writeable_arg0);
 }
 
 int main(int argc, char** argv)

--- a/src/CLI/usbguard.cpp
+++ b/src/CLI/usbguard.cpp
@@ -26,10 +26,16 @@
 #include <map>
 #include <iostream>
 
-#ifndef _GNU_SOURCE
-  #define _GNU_SOURCE
+#ifdef HAVE_GNU_BASENAME
+  /* GNU version of basename(3) */
+  #ifndef _GNU_SOURCE
+    #define _GNU_SOURCE
+  #endif
+  #include <cstring>
+#else
+  /* POSIX version of basename(3) */
+  #include <libgen.h>
 #endif
-#include <cstring> /* GNU version of basename(3) */
 
 #include "usbguard.hpp"
 #include "usbguard-get-parameter.hpp"

--- a/src/DBus/gdbus-server.cpp
+++ b/src/DBus/gdbus-server.cpp
@@ -20,7 +20,19 @@
   #include <build-config.h>
 #endif
 
-#include <stdlib.h>
+#ifdef HAVE_GNU_BASENAME
+  /* GNU version of basename(3) */
+  #ifndef _GNU_SOURCE
+    #define _GNU_SOURCE
+  #endif
+  #include <cstring>
+#else
+  /* POSIX version of basename(3) */
+  #include <libgen.h>
+#endif
+
+#include <cstdlib>  // e.g. for free(3)
+#include <cstring>  // e.g. for strdup(3)
 #include <iostream>
 #include <getopt.h>
 #include "DBusBridge.hpp"
@@ -208,13 +220,15 @@ static const struct ::option options_long[] = {
 
 static void showHelp(std::ostream& stream)
 {
-  stream << " Usage: " << ::basename(usbguard_arg0) << " [OPTIONS]" << std::endl;
+  char* const writeable_arg0 = ::strdup(usbguard_arg0);
+  stream << " Usage: " << ::basename(writeable_arg0) << " [OPTIONS]" << std::endl;
   stream << std::endl;
   stream << " Options:" << std::endl;
   stream << "  -s, --system   Listen on the system bus." << std::endl;
   stream << "  -S, --session  Listen on the session bus." << std::endl;
   stream << "  -h, --help     Show this help." << std::endl;
   stream << std::endl;
+  ::free(writeable_arg0);
 }
 
 int

--- a/src/Library/public/usbguard/Exception.hpp
+++ b/src/Library/public/usbguard/Exception.hpp
@@ -128,7 +128,7 @@ namespace usbguard
       char buffer[1024] = "Unknown error";
       const char* error_message = buffer;
       // See "man strerror_r" for why we need these two cases:
-#if defined(_POSIX_C_SOURCE) && (_POSIX_C_SOURCE >= 200112L) && ! defined(_GNU_SOURCE)
+#ifndef HAVE_GNU_STRERROR_R
       // We have the XSI-compliant version of strerror_r with int return
       strerror_r(errno_value, buffer, sizeof buffer);
 #else


### PR DESCRIPTION
It turns out that #510 needed more work and that function `basename` causes similar trouble.
So this pull request fixes both issues and adds related CI coverage, so we won't walk into musl regressions unnoticed.
I hope you like it :beers: 

CC @radosroka 