### PR TITLE
Fix compilation for PEGTL 3 with GCC 8 + make GitHub Actions cover GCC 8.5.0 (fixes #394)

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,48 @@
+##
+## Copyright (c) 2022 Sebastian Pipping <sebastian@pipping.org>
+##
+## This program is free software; you can redistribute it and/or modify
+## it under the terms of the GNU General Public License as published by
+## the Free Software Foundation; either version 2 of the License, or
+## (at your option) any later version.
+##
+## This program is distributed in the hope that it will be useful,
+## but WITHOUT ANY WARRANTY; without even the implied warranty of
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+## GNU General Public License for more details.
+##
+## You should have received a copy of the GNU General Public License
+## along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+name: Build on non-Ubuntu Linux using Docker
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  build_docker:
+    strategy:
+      fail-fast: false
+      matrix:
+        linux_distro:
+        - CentOS 8.2         # with GCC 8.5.0
+
+    name: Build on ${{ matrix.linux_distro }} using Docker
+    runs-on: ubuntu-20.04
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Build on ${{ matrix.linux_distro }} using Docker
+      run:  |
+        set -x
+
+        # Create tarballs used by Dockerfile
+        git submodule update --init
+        git archive -o usbguard.tar HEAD
+        ( cd src/ThirdParty/PEGTL/ && git archive -o ../../../pegtl.tar HEAD )
+
+        # Build using Docker
+        linux_distro="$(tr '[:upper:]' '[:lower:]' <<<"${{ matrix.linux_distro }}" | sed 's,[ .],_,g')"
+        docker build -f scripts/docker/build_on_"${linux_distro}".Dockerfile .

--- a/Makefile.am
+++ b/Makefile.am
@@ -28,6 +28,7 @@ EXTRA_DIST =\
 	VERSION \
 	CHANGELOG.md \
 	src/astylerc \
+	src/test_filesystem.cpp \
 	scripts/usbguard-zsh-completion \
 	scripts/modeline.vim \
 	scripts/astyle.sh \

--- a/configure.ac
+++ b/configure.ac
@@ -362,19 +362,43 @@ AC_SUBST([catch_CFLAGS])
 AC_SUBST([catch_LIBS])
 
 #
+# stdc++fs (for PEGTL >=3 below, e.g. with GCC 8)
+#
+STDCXX_FS_LINKTEST_FILENAME="${srcdir}"/src/test_filesystem.cpp
+STDCXX_FS_LINKTEST_SOURCE="$(cat "${STDCXX_FS_LINKTEST_FILENAME}")"
+AC_LANG_PUSH([C++])
+AC_MSG_CHECKING([whether we need to link to -lstdc++fs for PEGTL explicitly])
+AC_LINK_IFELSE([AC_LANG_SOURCE([${STDCXX_FS_LINKTEST_SOURCE}])], [
+    AC_MSG_RESULT([no])
+    stdcxxfs_LIBS=''
+], [
+    stdcxxfs_LIBS='-lstdc++fs'
+    SAVE_LIBS=${LIBS}
+    LIBS="${LIBS} ${stdcxxfs_LIBS}"
+    AC_LINK_IFELSE([AC_LANG_SOURCE([${STDCXX_FS_LINKTEST_SOURCE}])], [
+        AC_MSG_RESULT([yes])
+    ], [
+        AC_MSG_RESULT([ERROR])
+        AC_MSG_ERROR([Link test failed both with and without ${stdcxxfs_LIBS}; something is broken, please check file config.log for details.])
+    ])
+    LIBS=${SAVE_LIBS}
+])
+AC_LANG_POP()
+
+#
 # PEGTL C++ library
 #
 AC_ARG_WITH([bundled-pegtl], AS_HELP_STRING([--with-bundled-pegtl], [Build using the bundled PEGTL library]), [with_bundled_pegtl=$withval], [with_bundled_pegtl=no])
 if test "x$with_bundled_pegtl" = xyes; then
 	pegtl_CFLAGS="-I\$(top_srcdir)/src/ThirdParty/PEGTL/include"
 	pegtl_AC_CFLAGS="-I$srcdir/src/ThirdParty/PEGTL/include"
-	pegtl_LIBS=""
+	pegtl_LIBS="${stdcxxfs_LIBS}"
 	AC_MSG_NOTICE([Using bundled PEGTL library])
 	pegtl_summary="bundled; $pegtl_CFLAGS $pegtl_LIBS"
 else
 	pegtl_CFLAGS=""
 	pegtl_AC_CFLAGS=""
-	pegtl_LIBS=""
+	pegtl_LIBS="${stdcxxfs_LIBS}"
 	pegtl_summary="system-wide; $pegtl_CFLAGS $pegtl_LIBS"
 fi
 AC_SUBST([pegtl_CFLAGS])

--- a/scripts/docker/build_on_centos_8_2.Dockerfile
+++ b/scripts/docker/build_on_centos_8_2.Dockerfile
@@ -1,0 +1,51 @@
+##
+## Copyright (c) 2022 Sebastian Pipping <sebastian@pipping.org>
+##
+## This program is free software; you can redistribute it and/or modify
+## it under the terms of the GNU General Public License as published by
+## the Free Software Foundation; either version 2 of the License, or
+## (at your option) any later version.
+##
+## This program is distributed in the hope that it will be useful,
+## but WITHOUT ANY WARRANTY; without even the implied warranty of
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+## GNU General Public License for more details.
+##
+## You should have received a copy of the GNU General Public License
+## along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+FROM centos:8.2.2004
+RUN sed \
+            -e '/^baseurl=.*/d' \
+            -e 's,^mirrorlist=.*repo=\([^&]\+\).*,baseurl=http://linuxsoft.cern.ch/centos-vault/8.2.2004/\1/x86_64/os/,' \
+            -i /etc/yum.repos.d/CentOS-* \
+        && \
+    dnf clean metadata \
+        && \
+    dnf install -y epel-release dnf-plugins-core \
+        && \
+    dnf config-manager --set-enabled PowerTools \
+        && \
+    dnf install -y \
+            autoconf \
+            automake \
+            dbus-glib-devel \
+            diffutils \
+            file \
+            gcc-c++ \
+            git \
+            libgcrypt-devel \
+            libqb-devel \
+            libsodium-devel \
+            libtool \
+            libxslt \
+            make \
+            polkit-devel \
+            protobuf-compiler \
+            protobuf-devel
+ADD usbguard.tar usbguard/
+ADD pegtl.tar usbguard/src/ThirdParty/PEGTL/
+WORKDIR usbguard
+RUN git init &>/dev/null && ./autogen.sh
+RUN ./configure --with-bundled-catch --with-bundled-pegtl || ! cat config.log
+RUN make V=1 "-j$(nproc)"

--- a/src/Tests/Source/CheckScripts/private-with-build-config.sh
+++ b/src/Tests/Source/CheckScripts/private-with-build-config.sh
@@ -6,6 +6,7 @@
 # check-path-include: *.h
 # check-path-exclude: src/Library/public/*.hpp
 # check-path-exclude: src/Tests/*
+# check-path-exclude: src/test_filesystem.cpp
 #
 SOURCE_FILEPATH="$1"
 

--- a/src/test_filesystem.cpp
+++ b/src/test_filesystem.cpp
@@ -1,0 +1,24 @@
+//
+// Copyright (c) 2022 Sebastian Pipping <sebastian@pipping.org>
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#include <filesystem>
+
+int main()
+{
+  return std::filesystem::temp_directory_path().is_absolute();
+}
+
+/* vim: set ts=2 sw=2 et */


### PR DESCRIPTION
Fixes #394

This fixes the [link errors](https://github.com/USBGuard/usbguard/issues/394#issuecomment-1022530220) that happen with PEGTL 3 and GCC 8 on e.g. CentOS 8.2.
The CI part is the same approach as in PR #514 and I plan to rebase one onto the other, once either of them is merged.
I hope you like this direction, I'm looking forward to your review :beers: 

CC @Cropi @radosroka
