### PR TITLE
Use "make distcheck" in CI e.g. to protect against incomplete release archives

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,9 +2,7 @@ name: C/C++ CI
 
 on:
   push:
-    branches: [ master ]
   pull_request:
-    branches: [ master ]
 
 jobs:
   build:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -117,8 +117,5 @@ jobs:
         CC=${{ matrix.config.cc }} CXX=${{ matrix.config.cxx }} ../configure --enable-werror --disable-silent-rules --with-bundled-catch --with-bundled-pegtl --with-ldap --enable-full-test-suite ${{ matrix.config.configure_args }}
         make "-j$(nproc)"
 
-    - name: check
-      run: cd build && sudo make check
-
-    - name: dist
-      run: cd build && sudo make dist
+    - name: distcheck
+      run: sudo make -C build distcheck "-j$(nproc)"

--- a/Makefile.am
+++ b/Makefile.am
@@ -51,6 +51,10 @@ $(top_builddir)/src/build-config.h: $(top_builddir)/src/build-config.h.in
 DISTCLEANFILES=\
 	$(BUILT_SOURCES)
 
+AM_DISTCHECK_CONFIGURE_FLAGS=\
+	--with-bundled-catch \
+	--with-bundled-pegtl
+
 CLEANFILES=
 
 man_ADOC_FILES=\


### PR DESCRIPTION
Because one missing entry in `EXTRA_DIST` and the release is toast :smiley: 