### PR TITLE
Fix approach to "make distcheck" in GitHub Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -111,5 +111,8 @@ jobs:
         CC=${{ matrix.config.cc }} CXX=${{ matrix.config.cxx }} ../configure --enable-werror --disable-silent-rules --with-bundled-catch --with-bundled-pegtl --with-ldap --enable-full-test-suite ${{ matrix.config.configure_args }}
         make "-j$(nproc)"
 
+    - name: check
+      run: sudo make -C build check -j1 || { find -name test-suite.log -print -exec cat {} \; ; false ; }
+
     - name: distcheck
-      run: sudo make -C build distcheck "-j$(nproc)" || { cat src/Tests/test-suite.log ; false ; }
+      run: sudo make -C build distcheck -j1 || { find -name test-suite.log -print -exec cat {} \; ; false ; }

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -111,6 +111,13 @@ jobs:
         CC=${{ matrix.config.cc }} CXX=${{ matrix.config.cxx }} ../configure --enable-werror --disable-silent-rules --with-bundled-catch --with-bundled-pegtl --with-ldap --enable-full-test-suite ${{ matrix.config.configure_args }}
         make "-j$(nproc)"
 
+    - name: install (off-system, for coverage)
+      run: |-
+        set -x -o pipefail
+        make -C build DESTDIR="${PWD}"/ROOT install
+        find ROOT/ -not -type d | sort | xargs ls -l
+        rm -Rf find ROOT/  # to not interfere with check-driver.sh
+
     - name: check
       run: sudo make -C build check -j1 || { find -name test-suite.log -print -exec cat {} \; ; false ; }
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -52,6 +52,7 @@ DISTCLEANFILES=\
 	$(BUILT_SOURCES)
 
 AM_DISTCHECK_CONFIGURE_FLAGS=\
+	--enable-full-test-suite \
 	--with-bundled-catch \
 	--with-bundled-pegtl
 


### PR DESCRIPTION
- The test log file location for `make check` and `make distcheck` differs and was mixed up:
  - `make check` has `src/Tests/test-suite.log`.
  - `make distcheck` has `usbguard-*/_build/sub/src/Tests/test-suite.log`.

  The new approach unhardcodes the path to avoid regressions, and dumps both if available.

- `make distcheck` has its own set of configure arguments (in variable `AM_DISTCHECK_CONFIGURE_FLAGS`) and so (while of value) was not a good substitute for `make check` (with custom configure arguments). So now both `make check` and `make distcheck` are run.

- Both `make check` nor `make distcheck` and have turned out not to fully robust towards `-j$(nproc)`, so now make option `-j1` is used to make that explicit.

CC @radosroka 