### PR TITLE
Fix build CI on master / configure.ac: Bring back -static-libasan for GCC where supported

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -573,6 +573,9 @@ if test "x$enable_asan" = xyes; then
   AX_CHECK_COMPILE_FLAG([-fno-omit-frame-pointer],
                         [ASAN_FLAGS="$ASAN_FLAGS -fno-omit-frame-pointer"],
                         [], [])
+  AX_CHECK_COMPILE_FLAG([-static-libasan],
+                        [ASAN_FLAGS="$ASAN_FLAGS -static-libasan"],
+                        [], [])
   AC_LANG_POP
 fi
 #


### PR DESCRIPTION
@radosroka I'm not sure how the CI could first be all green for #517 and then turn red after merge (from de05297e6e580954b89afa83391344e8c34c3c7b) on `master` but error message…

> `==43266==ASan runtime does not come first in initial library list; you should either link runtime to your application or manually preload it with LD_PRELOAD.` 

…says something. So I'm bringing `-static-libasan` back for GCC for now, in a way that doesn't harm Clang (where the argument seems neither supported nor needed).