### PR TITLE
Improve Readme (Ubuntu 21.10 instructions, help with first start, more) + make CI cover Ubuntu 21.10 (fixes #474, fixes #500)

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -28,6 +28,7 @@ jobs:
         linux_distro:
         - Alpine Linux 3.15  # with musl
         - CentOS 8.2         # with GCC 8.5.0
+        - Ubuntu 21.10       # because super popular
 
     name: Build on ${{ matrix.linux_distro }} using Docker
     runs-on: ubuntu-20.04

--- a/README.adoc
+++ b/README.adoc
@@ -17,12 +17,6 @@ image::https://img.shields.io/github/license/USBGuard/usbguard.svg[License, link
 USBGuard is a software framework for implementing USB device authorization policies (what kind of USB devices are authorized) as well as method of use policies (how a USB device may interact with the system).
 Simply put, it is a USB device allowlisting tool.
 
-WARNING: The 0.x releases are not production ready packages.
-They serve for tech-preview and user feedback purposes only.
-Please share your feedback or request a feature in the Github issue trackers for each project:
-
- * https://github.com/USBGuard/usbguard/issues/new[Report a bug or request a feature in *usbguard*]
-
 == Documentation
 
  * User Guide (TBA)
@@ -34,6 +28,14 @@ Please share your feedback or request a feature in the Github issue trackers for
  ** <<doc/man/usbguard-dbus.8.adoc#name, usbguard-dbus(8)>>
 
 == Compilation & Installation
+
+WARNING: *Prior to starting the USBGuard daemon (or service) for the first time*
+         (but after installation)
+         we need to
+         generate a rules file for USBGuard so that the currently attached
+         USB devices (in particular mouse and keyboard) keep working
+         so that you will not **get locked out of your system**.
+         More on that below at <<before-the-first-start, Before the First Start>>.
 
 To compile the source code, you will require at least C{plus}{plus}17. +
 If you are compiling sources from a release tarball, you'll need the development files for:
@@ -48,19 +50,61 @@ Optionally, you may want to install:
  * https://github.com/seccomp/libseccomp[libseccomp] - used to implement a syscall whitelist
  * https://people.redhat.com/sgrubb/libcap-ng/[libcap-ng] - used to drop process capabilities
 
+If you are on a Debian based GNU/Linux distribution like Ubuntu 21.10,
+installation of all build dependencies would be something like this:
+
+    $ sudo apt update && \
+      sudo apt install --no-install-recommends -V \
+        asciidoc autoconf automake bash-completion build-essential catch \
+        docbook-xml docbook-xsl git ldap-utils libaudit-dev libcap-ng-dev \
+        libdbus-glib-1-dev libldap-dev libpolkit-gobject-1-dev libprotobuf-dev \
+        libqb-dev libseccomp-dev libsodium-dev libtool libxml2-utils \
+        libumockdev-dev pkg-config protobuf-compiler sudo tao-pegtl-dev xsltproc
+
 And then do:
 
-    $ ./configure --with-crypto-library=sodium # or "gcrypt", based on your preference
+    $ ./configure        # for arguments of interest see below
     $ make
+    $ make check         # if you would like to run the test suite
     $ sudo make install
 
-After the sources are successfully built, you can run the test suite by executing:
+Configure arguments that deserve explicit mentioning (quoting `./configure --help` output):
 
-    $ make check
+      --enable-systemd        install the systemd service unit file (default=no)
+
+      --with-crypto-library   Select crypto backend library. Supported values:
+                              sodium, gcrypt, openssl.
+
+      --with-bundled-catch    Build using the bundled Catch library
+
+      --with-bundled-pegtl    Build using the bundled PEGTL library
+
+      --with-ldap             Build USBGuard with ldap support
 
 If you want to compile the sources in a cloned repository, you'll have to run the `./autogen.sh` script.
 It will fetch the sources (via git submodules) of https://github.com/taocpp/PEGTL/[PEGTL] and https://github.com/philsquared/Catch[Catch].
-The script will then initialize the autotools based build system.
+The script will then initialize the autotools based build system, e.g. generate the `./configure` script.
+
+== Before the First Start
+
+*Prior to starting the USBGuard daemon (or service) for the first time*
+(but after installation)
+we need to
+generate a rules file for USBGuard so that the currently attached
+USB devices (in particular mouse and keyboard) keep working
+so that you will not **get locked out of your system**.
+
+A rules file can be generated like this:
+
+    $ sudo sh -c 'usbguard generate-policy > /etc/usbguard/rules.conf'
+
+After that, you can safely start service `usbguard`:
+
+    $ sudo systemctl start usbguard.service
+
+And you can make systemd start the service every time your boot your machine:
+
+    $ sudo systemctl enable usbguard.service
 
 == License
 

--- a/scripts/docker/build_on_ubuntu_21_10.Dockerfile
+++ b/scripts/docker/build_on_ubuntu_21_10.Dockerfile
@@ -1,0 +1,54 @@
+##
+## Copyright (c) 2022 Sebastian Pipping <sebastian@pipping.org>
+##
+## This program is free software; you can redistribute it and/or modify
+## it under the terms of the GNU General Public License as published by
+## the Free Software Foundation; either version 2 of the License, or
+## (at your option) any later version.
+##
+## This program is distributed in the hope that it will be useful,
+## but WITHOUT ANY WARRANTY; without even the implied warranty of
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+## GNU General Public License for more details.
+##
+## You should have received a copy of the GNU General Public License
+## along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+FROM ubuntu:21.10
+RUN apt-get update \
+      && \
+    DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends --yes -V \
+            asciidoc \
+            autoconf \
+            automake \
+            bash-completion \
+            build-essential \
+            catch \
+            docbook-xml \
+            docbook-xsl \
+            git \
+            ldap-utils \
+            libaudit-dev \
+            libcap-ng-dev \
+            libdbus-glib-1-dev \
+            libldap-dev \
+            libpolkit-gobject-1-dev \
+            libprotobuf-dev \
+            libqb-dev \
+            libseccomp-dev \
+            libsodium-dev \
+            libtool \
+            libxml2-utils \
+            libumockdev-dev \
+            pkg-config \
+            protobuf-compiler \
+            sudo \
+            systemd \
+            tao-pegtl-dev \
+            xsltproc
+ADD usbguard.tar usbguard/
+WORKDIR usbguard
+RUN git init &>/dev/null && ./autogen.sh
+RUN ./configure --enable-systemd || ! cat config.log
+RUN make V=1 "-j$(nproc)"
+RUN make V=1 check || { cat src/Tests/test-suite.log ; false ; }


### PR DESCRIPTION
Fixes #474 — Installation procedure and doc could be better
Fixes #500 — Ubuntu install instructions (for 21.10)