### PR TITLE
Migrate from Catch 1 to Catch 2 (v2.13.8)

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -55,7 +55,7 @@ installation of all build dependencies would be something like this:
 
     $ sudo apt update && \
       sudo apt install --no-install-recommends -V \
-        asciidoc autoconf automake bash-completion build-essential catch \
+        asciidoc autoconf automake bash-completion build-essential catch2 \
         docbook-xml docbook-xsl git ldap-utils libaudit-dev libcap-ng-dev \
         libdbus-glib-1-dev libldap-dev libpolkit-gobject-1-dev libprotobuf-dev \
         libqb-dev libseccomp-dev libsodium-dev libtool libxml2-utils \

--- a/configure.ac
+++ b/configure.ac
@@ -388,17 +388,17 @@ fi
 #
 AC_ARG_WITH([bundled-catch], AS_HELP_STRING([--with-bundled-catch], [Build using the bundled Catch library]), [with_bundled_catch=$withval], [with_bundled_catch=no])
 if test "x$with_bundled_catch" = xyes; then
-	catch_CFLAGS="-I\$(top_srcdir)/src/ThirdParty/Catch/include"
+	catch_CFLAGS="-I\$(top_srcdir)/src/ThirdParty/Catch/single_include/catch2"
 	catch_LIBS=""
 	AC_MSG_NOTICE([Using bundled Catch library])
 	catch_summary="bundled; $catch_CFLAGS $catch_LIBS"
 else
 	SAVE_CPPFLAGS=$CPPFLAGS
-	CPPFLAGS="-std=c++17 $CPPFLAGS -I/usr/include/catch"
+	CPPFLAGS="-std=c++17 $CPPFLAGS -I/usr/include/catch2"
 	AC_LANG_PUSH([C++])
 	AC_CHECK_HEADER([catch.hpp], [], [AC_MSG_FAILURE(catch.hpp not found or not usable. Re-run with --with-bundled-catch to use the bundled library.)])
 	AC_LANG_POP
-	catch_CFLAGS="-I/usr/include/catch"
+	catch_CFLAGS="-I/usr/include/catch2"
 	catch_LIBS=""
 	CPPFLAGS=$SAVE_CPPFLAGS
 	catch_summary="system-wide; $catch_CFLAGS $catch_LIBS"

--- a/scripts/docker/build_on_ubuntu_21_10.Dockerfile
+++ b/scripts/docker/build_on_ubuntu_21_10.Dockerfile
@@ -23,7 +23,7 @@ RUN apt-get update \
             automake \
             bash-completion \
             build-essential \
-            catch \
+            catch2 \
             docbook-xml \
             docbook-xsl \
             git \


### PR DESCRIPTION
https://github.com/catchorg/Catch2/commit/216713a4066b79d9803d374f261ccb30c0fb451f

Note: LGTM failure is unrelated, see #528