### PR TITLE
Fix LGTM CI (by updating bundled PEGTL from 3.2.3 to 3.2.5 for GCC 9.2)

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -28,6 +28,7 @@ jobs:
         linux_distro:
         - Alpine Linux 3.15  # with musl
         - CentOS 8.2         # with GCC 8.5.0
+        - Debian Buster with GCC 9.2  # stock buster has GCC 8.3
         - Ubuntu 21.10       # because super popular
 
     name: Build on ${{ matrix.linux_distro }} using Docker

--- a/.lgtm.yml
+++ b/.lgtm.yml
@@ -16,4 +16,7 @@ extraction:
       - ./autogen.sh
 
     configure:
-      command: ./configure --with-bundled-pegtl
+      command: |-
+        ${CC:-cc} --version
+        ${CXX:-c++} --version
+        ./configure --with-bundled-pegtl || { cat config.log ; false ; }

--- a/scripts/docker/build_on_debian_buster_with_gcc_9_2.Dockerfile
+++ b/scripts/docker/build_on_debian_buster_with_gcc_9_2.Dockerfile
@@ -1,0 +1,62 @@
+##
+## Copyright (c) 2022 Sebastian Pipping <sebastian@pipping.org>
+##
+## This program is free software; you can redistribute it and/or modify
+## it under the terms of the GNU General Public License as published by
+## the Free Software Foundation; either version 2 of the License, or
+## (at your option) any later version.
+##
+## This program is distributed in the hope that it will be useful,
+## but WITHOUT ANY WARRANTY; without even the implied warranty of
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+## GNU General Public License for more details.
+##
+## You should have received a copy of the GNU General Public License
+## along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+FROM gcc:9.2
+SHELL ["/bin/bash", "-c"]
+RUN head -n1 /etc/os-release \
+        && \
+    apt-get update \
+        && \
+    DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends --yes -V \
+            asciidoc \
+            autoconf \
+            automake \
+            bash-completion \
+            build-essential \
+            catch \
+            docbook-xml \
+            docbook-xsl \
+            git \
+            ldap-utils \
+            libaudit-dev \
+            libcap-ng-dev \
+            libdbus-glib-1-dev \
+            libldap-dev \
+            libpolkit-gobject-1-dev \
+            libprotobuf-dev \
+            libqb-dev \
+            libseccomp-dev \
+            libsodium-dev \
+            libtool \
+            libxml2-utils \
+            libumockdev-dev \
+            pkg-config \
+            protobuf-compiler \
+            sudo \
+            systemd \
+            tao-pegtl-dev \
+            xsltproc
+RUN set -x \
+        && \
+    [[ "$(gcc -dumpversion) == 9.2.* ]] \
+        && \
+    [[ "$(g++ -dumpversion) == 9.2.* ]]
+ADD usbguard.tar usbguard/
+WORKDIR usbguard
+RUN git init &>/dev/null && ./autogen.sh
+RUN ./configure --enable-systemd || ! cat config.log
+RUN make V=1 "-j$(nproc)"
+RUN make V=1 check || { cat src/Tests/test-suite.log ; false ; }


### PR DESCRIPTION
The story here is that:
- LGTM is using C++ compiler `c++ (Ubuntu 9.2.1-9ubuntu2) 9.2.1 20191008` when probing USBGuard code.
- Our PEGTL 3.2.3 turned out to have a [compile error issue with GCC 9.2](https://github.com/taocpp/PEGTL/issues/303).
- LGTM does not inspect submodule updates, so it failed to fail the CI of PR #521.
- All that combined broke the LGTM integration on `master` and causes the red CI crosses that we see today.

For a fix:
- (While LGTM also has Clang 9 available, switching the LGTM config to Clang would not fix the compile error at the source.)
- Hence I'm updating our bundled PEGTL to upstream 3.2.5 with the GCC 9.2 fixes, extend the LGTM config to be more helpful with similar issues in the future, and make GitHub Actions cover GCC 9.2 explicitly to detect future regressions independent from LGTM.

CC @radosroka 