### PR TITLE
[security] Fix unauthorized access via D-Bus (fixes #273, fixes #403)

### DIFF
--- a/.github/workflows/polkit.yml
+++ b/.github/workflows/polkit.yml
@@ -1,0 +1,67 @@
+##
+## Copyright (c) 2022 Sebastian Pipping <sebastian@pipping.org>
+##
+## This program is free software; you can redistribute it and/or modify
+## it under the terms of the GNU General Public License as published by
+## the Free Software Foundation; either version 2 of the License, or
+## (at your option) any later version.
+##
+## This program is distributed in the hope that it will be useful,
+## but WITHOUT ANY WARRANTY; without even the implied warranty of
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+## GNU General Public License for more details.
+##
+## You should have received a copy of the GNU General Public License
+## along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+name: Check for Polkit policy parse errors
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  polkit_policies:
+
+    name: Check for Polkit policy parse errors
+    runs-on: ubuntu-20.04
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Install runtime dependencies
+      run:  |
+        set -x
+        sudo apt-get update
+        sudo apt-get install --no-install-recommends --yes -V expat
+
+    - name: Check for Polkit policy parse errors
+      run:  |
+        # This will work around pkaction exiting with unjustified(?)
+        # code 1 on Ubuntu 20.04
+        check_polkit_action() { pkaction -v -a "$1" | tee /dev/stderr | fgrep -q 'implicit any' ; }
+
+        set -x
+        actions=(
+            org.usbguard.Devices1.listDevices
+            org.usbguard.Devices1.applyDevicePolicy
+            org.usbguard.Policy1.appendRule
+            org.usbguard.Policy1.listRules
+            org.usbguard.Policy1.removeRule
+            org.usbguard1.getParameter
+            org.usbguard1.setParameter
+        )
+
+        # Self-test: Assert that prior to installation, our Polkit "actions"
+        # are unknown to PolKit.
+        ! check_polkit_action "${actions[0]}"
+
+        # Install the policy so that polkin can find it
+        xmlwf      src/DBus/org.usbguard1.policy
+        sudo cp -v src/DBus/org.usbguard1.policy /usr/share/polkit-1/actions/
+
+        # Assert that after installation, all of our Polkit "actions" are known.
+        # This detects parse error regressions.
+        for action in "${actions[@]}"; do
+            check_polkit_action "${action}"
+        done

--- a/configure.ac
+++ b/configure.ac
@@ -467,7 +467,7 @@ if test "x$with_dbus" = xyes; then
   #
   # Check for required D-Bus modules
   #
-  PKG_CHECK_MODULES([dbus], [dbus-1 gio-2.0],
+  PKG_CHECK_MODULES([dbus], [dbus-1 gio-2.0 polkit-gobject-1],
   [AC_DEFINE([HAVE_DBUS], [1], [Required GDBus API available])
   dbus_summary="system-wide; $dbus_CFLAGS $dbus_LIBS"],
   [AC_MSG_FAILURE([Required D-Bus modules (dbus-1, gio-2.0) not found!])]

--- a/src/DBus/DBusBridge.hpp
+++ b/src/DBus/DBusBridge.hpp
@@ -88,6 +88,8 @@ namespace usbguard
       bool rule_match,
       uint32_t rule_id);
 
+    static std::string formatGError(GError* error);
+    static bool isAuthorizedByPolkit(GDBusMethodInvocation* invocation);
 
     GDBusConnection* const p_gdbus_connection;
     void(*p_ipc_callback)(bool);

--- a/src/DBus/org.usbguard1.policy
+++ b/src/DBus/org.usbguard1.policy
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE policyconfig PUBLIC "-//freedesktop//DTD PolicyKit Policy Configuration 1.0//EN"
         "http://www.freedesktop.org/standards/PolicyKit/1/policyconfig.dtd">
-        
+
 <policyconfig>
   <vendor>The USBGuard Project</vendor>
   <vendor_url>https://github.org/USBGuard/usbguard</vendor_url>

--- a/src/DBus/org.usbguard1.policy
+++ b/src/DBus/org.usbguard1.policy
@@ -8,7 +8,7 @@
 
   <action id="org.usbguard.Policy1.listRules">
     <description>List the rule set (policy) used by the USBGuard daemon</description>
-    <message>Prevents from listing the USBGuard policy</message>
+    <message>Prevents listing the USBGuard policy</message>
     <defaults>
       <allow_inactive>no</allow_inactive>
       <allow_active>auth_self_keep</allow_active>
@@ -17,7 +17,7 @@
 
   <action id="org.usbguard.Policy1.appendRule">
     <description>Append a new rule to the policy</description>
-    <message>Prevents from appending rules to the USBGuard policy</message>
+    <message>Prevents appending rules to the USBGuard policy</message>
     <defaults>
       <allow_inactive>no</allow_inactive>
       <allow_active>auth_admin</allow_active>
@@ -35,7 +35,7 @@
 
   <action id="org.usbguard.Devices1.listDevices">
     <description>List all USB devices recognized by the USBGuard daemon</description>
-    <message>Prevents from listing USB devices recognized by the USBGuard daemon</message>
+    <message>Prevents listing USB devices recognized by the USBGuard daemon</message>
     <defaults>
       <allow_inactive>no</allow_inactive>
       <allow_active>auth_self_keep</allow_active>

--- a/src/DBus/org.usbguard1.policy
+++ b/src/DBus/org.usbguard1.policy
@@ -11,7 +11,7 @@
     <message>Prevents from listing the USBGuard policy</message>
     <defaults>
       <allow_inactive>no</allow_inactive>
-      <allow_active>auth_self_keep_session</allow_active>
+      <allow_active>auth_self_keep</allow_active>
     </defaults>
   </action>
 
@@ -38,7 +38,7 @@
     <message>Prevents from listing USB devices recognized by the USBGuard daemon</message>
     <defaults>
       <allow_inactive>no</allow_inactive>
-      <allow_active>auth_self_keep_session</allow_active>
+      <allow_active>auth_self_keep</allow_active>
     </defaults>
   </action>
 

--- a/src/DBus/org.usbguard1.policy
+++ b/src/DBus/org.usbguard1.policy
@@ -33,12 +33,39 @@
     </defaults>
   </action>
 
+  <action id="org.usbguard.Devices1.applyDevicePolicy">
+    <description>Apply a policy to a device in USBGuard</description>
+    <message>Prevents applying a policy to a device in USBGuard</message>
+    <defaults>
+      <allow_inactive>no</allow_inactive>
+      <allow_active>auth_admin</allow_active>
+    </defaults>
+  </action>
+
   <action id="org.usbguard.Devices1.listDevices">
     <description>List all USB devices recognized by the USBGuard daemon</description>
     <message>Prevents listing USB devices recognized by the USBGuard daemon</message>
     <defaults>
       <allow_inactive>no</allow_inactive>
       <allow_active>auth_self_keep</allow_active>
+    </defaults>
+  </action>
+
+  <action id="org.usbguard1.getParameter">
+    <description>Get the value of a runtime parameter</description>
+    <message>Prevents getting values of runtime USBGuard parameters</message>
+    <defaults>
+      <allow_inactive>no</allow_inactive>
+      <allow_active>auth_self_keep</allow_active>
+    </defaults>
+  </action>
+
+  <action id="org.usbguard1.setParameter">
+    <description>Set the value of a runtime parameter</description>
+    <message>Prevents setting values of runtime USBGuard parameters</message>
+    <defaults>
+      <allow_inactive>no</allow_inactive>
+      <allow_active>auth_admin</allow_active>
     </defaults>
   </action>
 </policyconfig>

--- a/src/DBus/org.usbguard1.policy
+++ b/src/DBus/org.usbguard1.policy
@@ -41,32 +41,5 @@
       <allow_active>auth_self_keep</allow_active>
     </defaults>
   </action>
-
-  <action id="org.usbguard.Devices1.allowDevice">
-    <description>Authorize a USB device via the USBGuard daemon to interact with the system</description>
-    <message>Prevents from authorizing USB devices via the USBGuard daemon</message>
-    <defaults>
-      <allow_inactive>no</allow_inactive>
-      <allow_active>auth_admin</allow_active>
-    </defaults>
-  </action>
-
-  <action id="org.usbguard.Devices1.blockDevice">
-    <description>Deauthorize a USB device via the USBGuard daemon</description>
-    <message>Prevents from deauthorizing USB devices via the USBGuard daemon</message>
-    <defaults>
-      <allow_inactive>no</allow_inactive>
-      <allow_active>auth_admin</allow_active>
-    </defaults>
-  </action>
-
-  <action id="org.usbguard.Devices1.rejectDevice">
-    <description>Remove a USB device via the USBGuard daemon</description>
-    <message>Prevents from removing USB devices via the USBGuard daemon</message>
-    <defaults>
-      <allow_inactive>no</allow_inactive>
-      <allow_active>auth_admin</allow_active>
-    </defaults>
-  </action>
 </policyconfig>
 


### PR DESCRIPTION
Fixes #273
Fixes #403

- Fix `.policy` file:
  - Replace unsupported value `auth_self_keep_session` by `auth_self_keep` to fix the Polkit parse error so that Polkit stops ignoring the USBGuard `.policy` file.
  - Drop actions/methods from the policy that no longer exist.
  - Add actions/methods to the policy file that have been missing.
- Make `usbguard-dbus` call out to Polkit for authorization so that the policies from the `.policy` file are actually respected.
- Add CI to protect against policy file parse error regressions.

CC @radosroka @Cropi 