### PR TITLE
usbguard-daemon: Fix rules file opening error message (fixes #529)

### DIFF
--- a/src/Daemon/Daemon.cpp
+++ b/src/Daemon/Daemon.cpp
@@ -411,6 +411,9 @@ namespace usbguard
     catch (const RuleParserError& ex) {
       throw Exception("Rules", _nss.getSourceInfo(), ex.hint());
     }
+    catch (const Exception& ex) {
+      throw ex;
+    }
     catch (const std::exception& ex) {
       throw Exception("Rules", _nss.getSourceInfo(), ex.what());
     }

--- a/src/Tests/LDAP/UseCase/ldap-test-3.sh
+++ b/src/Tests/LDAP/UseCase/ldap-test-3.sh
@@ -120,7 +120,7 @@ then
     KILLRC="0"
 fi
 
-grep "Rules: SourceLDAP: usbguard::Exception" $TMPDIR/usbguard.log
+grep "LDAPHandler query: ldap_search_ext_s: No such object" $TMPDIR/usbguard.log
 GREP1=$?
 
 grep -i "Sanitizer" $TMPDIR/usbguard.log


### PR DESCRIPTION
Fixes #529

New behavior:
```console
$ ./usbguard-daemon -P -c <(echo 'RuleFile=/no/such/file') -k
[1644856721.986] (W) PERMISSIONS CHECK ON POLICY FILE ARE TURNED OFF!
[1644856721.987] (E) FileRuleSet loading: /no/such/file: No such file or directory
```