### PR TITLE
Resolve small Catch 1.x leftover

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -45,6 +45,7 @@ jobs:
         git submodule update --init
         git archive -o usbguard.tar HEAD
         ( cd src/ThirdParty/PEGTL/ && git archive -o ../../../pegtl.tar HEAD )
+        ( cd src/ThirdParty/Catch/ && git archive -o ../../../catch.tar HEAD )
 
         # Build using Docker
         linux_distro="$(tr '[:upper:]' '[:lower:]' <<<"${{ matrix.linux_distro }}" | sed 's,[ .],_,g')"

--- a/scripts/docker/build_on_alpine_linux_3_15.Dockerfile
+++ b/scripts/docker/build_on_alpine_linux_3_15.Dockerfile
@@ -36,6 +36,7 @@ RUN echo '@edge-testing https://dl-cdn.alpinelinux.org/alpine/edge/testing' >> /
             polkit-dev \
             protobuf-dev
 ADD usbguard.tar usbguard/
+ADD catch.tar usbguard/src/ThirdParty/Catch/
 WORKDIR usbguard
 RUN git init &>/dev/null && ./autogen.sh
 RUN ./configure --with-bundled-catch || ! cat config.log

--- a/scripts/docker/build_on_centos_8_2.Dockerfile
+++ b/scripts/docker/build_on_centos_8_2.Dockerfile
@@ -44,6 +44,7 @@ RUN sed \
             protobuf-compiler \
             protobuf-devel
 ADD usbguard.tar usbguard/
+ADD catch.tar usbguard/src/ThirdParty/Catch/
 ADD pegtl.tar usbguard/src/ThirdParty/PEGTL/
 WORKDIR usbguard
 RUN git init &>/dev/null && ./autogen.sh

--- a/scripts/docker/build_on_debian_buster_with_gcc_9_2.Dockerfile
+++ b/scripts/docker/build_on_debian_buster_with_gcc_9_2.Dockerfile
@@ -26,7 +26,6 @@ RUN head -n1 /etc/os-release \
             automake \
             bash-completion \
             build-essential \
-            catch \
             docbook-xml \
             docbook-xsl \
             git \
@@ -55,8 +54,9 @@ RUN set -x \
         && \
     [[ "$(g++ -dumpversion) == 9.2.* ]]
 ADD usbguard.tar usbguard/
+ADD catch.tar usbguard/src/ThirdParty/Catch/
 WORKDIR usbguard
 RUN git init &>/dev/null && ./autogen.sh
-RUN ./configure --enable-systemd || ! cat config.log
+RUN ./configure --enable-systemd --with-bundled-catch || ! cat config.log
 RUN make V=1 "-j$(nproc)"
 RUN make V=1 check || { cat src/Tests/test-suite.log ; false ; }

--- a/scripts/docker/build_on_ubuntu_21_10.Dockerfile
+++ b/scripts/docker/build_on_ubuntu_21_10.Dockerfile
@@ -16,7 +16,7 @@
 
 FROM ubuntu:21.10
 RUN apt-get update \
-      && \
+        && \
     DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends --yes -V \
             asciidoc \
             autoconf \


### PR DESCRIPTION
Note that Debian buster doesn't have Catch 2.x.

(Leftover was caused by parallel development of #527 (removing Catch 1.x) and #528 (adding more Catch 1.x).)

Includes a few related changes that I am happy to extract to dedicated pull requests, as you prefer or see needed.


