### PR TITLE
dbus: check whether the client wanted interactive authentication

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -467,7 +467,7 @@ if test "x$with_dbus" = xyes; then
   #
   # Check for required D-Bus modules
   #
-  PKG_CHECK_MODULES([dbus], [dbus-1 gio-2.0 polkit-gobject-1],
+  PKG_CHECK_MODULES([dbus], [dbus-1 gio-2.0 >= 2.46 polkit-gobject-1],
   [AC_DEFINE([HAVE_DBUS], [1], [Required GDBus API available])
   dbus_summary="system-wide; $dbus_CFLAGS $dbus_LIBS"],
   [AC_MSG_FAILURE([Required D-Bus modules (dbus-1, gio-2.0) not found!])]

--- a/src/DBus/DBusBridge.cpp
+++ b/src/DBus/DBusBridge.cpp
@@ -477,7 +477,11 @@ namespace usbguard
     polkit_details_insert (details, "polkit.message", "This USBGuard action needs authorization");
     USBGUARD_LOG(Trace) << "Customized.";
     USBGUARD_LOG(Trace) << "Checking authorization of action \"" << action_id.str() << "\" with Polkit ...";
-    const PolkitCheckAuthorizationFlags flags = POLKIT_CHECK_AUTHORIZATION_FLAGS_ALLOW_USER_INTERACTION;
+    GDBusMessage* const message = g_dbus_method_invocation_get_message (invocation);
+    const PolkitCheckAuthorizationFlags flags = (g_dbus_message_get_flags (message) &
+        G_DBUS_MESSAGE_FLAGS_ALLOW_INTERACTIVE_AUTHORIZATION)
+      ? POLKIT_CHECK_AUTHORIZATION_FLAGS_ALLOW_USER_INTERACTION
+      : POLKIT_CHECK_AUTHORIZATION_FLAGS_NONE;
     PolkitAuthorizationResult* const result = polkit_authority_check_authorization_sync
       (authority,
         subject,


### PR DESCRIPTION
Some clients do not want to prompt for passwords, e.g. when authorising keyboards
when the screen is locked, prompting for a password doesn't make sense because
the user cannot enter anything.
This change extracts the flags and checks whether the client called with
G_DBUS_CALL_FLAGS_ALLOW_INTERACTIVE_AUTHORIZATION.