### PR TITLE
D-Bus: Send reply on auth failure

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -470,7 +470,7 @@ if test "x$with_dbus" = xyes; then
   PKG_CHECK_MODULES([dbus], [dbus-1 gio-2.0 polkit-gobject-1],
   [AC_DEFINE([HAVE_DBUS], [1], [Required GDBus API available])
   dbus_summary="system-wide; $dbus_CFLAGS $dbus_LIBS"],
-  [AC_MSG_FAILURE([Required D-Bus modules (dbus-1, gio-2.0) not found!])]
+  [AC_MSG_FAILURE([Required D-Bus modules (dbus-1, gio-2.0, polkit-gobject-1) not found!])]
   )
 
   #

--- a/src/DBus/DBusBridge.hpp
+++ b/src/DBus/DBusBridge.hpp
@@ -89,7 +89,7 @@ namespace usbguard
       uint32_t rule_id);
 
     static std::string formatGError(GError* error);
-    static bool isAuthorizedByPolkit(GDBusMethodInvocation* invocation);
+    static bool isAuthorizedByPolkit(GDBusMethodInvocation* invocation, GDBusError* authError, const gchar** authErrorMessage);
 
     GDBusConnection* const p_gdbus_connection;
     void(*p_ipc_callback)(bool);


### PR DESCRIPTION
In reaction to comment https://github.com/USBGuard/usbguard/pull/546#issuecomment-1100214103 by @benzea.

The effect can be seen e.g. when running…
```console
$ dbus-send --system --print-reply --dest=org.usbguard1 /org/usbguard1 org.usbguard1.getParameter string:ImplicitPolicyTarget
```
… (as non-root) and then hitting the `Cancel` button in the PolKit auth dialog. Previously, `dbus-send` would continue to run waiting for a reply that is not coming with this pull request applied it shuts down properly saying:
```
Error org.freedesktop.DBus.Error.AccessDenied: Not authorized.
```
as expected.

Note that there are no changes to whether _interactive_ authentication is requested from Polkit.

CC @benzea @radosroka @muelli 