### PR TITLE
Unreference PolkitAuthorizationResult and PolkitAuthority structs if needed

### DIFF
--- a/src/DBus/DBusBridge.cpp
+++ b/src/DBus/DBusBridge.cpp
@@ -492,12 +492,11 @@ namespace usbguard
     USBGUARD_LOG(Trace) << "Connecting with Polkit authority...";
     PolkitAuthority* const authority = polkit_authority_get_sync(/*cancellable=*/ NULL, &error);
 
-    if (! authority || error) {
+    if (! authority) {
       USBGUARD_LOG(Trace) << "Failed to connect to Polkit authority: " << formatGError(error) << ".";
       *authErrorCode = G_DBUS_ERROR_AUTH_FAILED;
       *authErrorMessage = "Failed to connect to Polkit authority";
       g_error_free(error);
-      g_object_unref(authority);
       g_object_unref(subject);
       return false;
     }
@@ -528,12 +527,11 @@ namespace usbguard
         /*cancellable=*/ NULL,
         &error);
 
-    if (! result || error) {
+    if (! result) {
       USBGUARD_LOG(Trace) << "Failed to check back with Polkit for authoriation: " << formatGError(error) << ".";
       *authErrorCode = G_DBUS_ERROR_AUTH_FAILED;
       *authErrorMessage = "Failed to check back with Polkit for authoriation.";
       g_error_free(error);
-      g_object_unref(result);
       g_object_unref(details);
       g_object_unref(authority);
       g_object_unref(subject);


### PR DESCRIPTION
1. If ```polkit_authority_get_sync()``` fails, then it will return null, so there is no need to free it with ```g_object_unref()```.
2. The same goes for ```polkit_authority_check_authorization_sync()```. The documentation says the following: "A ```PolkitAuthorizationResult``` is returned or NULL if error is set. Free with g_object_unref()."

I came across this issue when SElinux did not allow usbguard-dbus to perform the mentioned actions. Thus, usbguard tried to free memory, which was not even allocated.

[1] https://www.freedesktop.org/software/polkit/docs/latest/PolkitAuthority.html