### PR TITLE
GitHub Actions: Fix Ubuntu Docker build (by migrating from 21.10 to 22.04)

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -29,7 +29,7 @@ jobs:
         - Alpine Linux 3.15  # with musl
         - CentOS 8.2         # with GCC 8.5.0
         - Debian Buster with GCC 9.2  # stock buster has GCC 8.3
-        - Ubuntu 21.10       # because super popular
+        - Ubuntu 22.04       # because super popular
 
     name: Build on ${{ matrix.linux_distro }} using Docker
     runs-on: ubuntu-20.04

--- a/scripts/docker/build_on_ubuntu_22_04.Dockerfile
+++ b/scripts/docker/build_on_ubuntu_22_04.Dockerfile
@@ -14,7 +14,7 @@
 ## You should have received a copy of the GNU General Public License
 ## along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-FROM ubuntu:21.10
+FROM ubuntu:22.04
 RUN apt-get update \
         && \
     DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends --yes -V \


### PR DESCRIPTION
Related error log at https://github.com/USBGuard/usbguard/runs/7914037604?check_suite_focus=true

CC @Cropi 