### PR TITLE
The parent process should wait for the first child process to finish in forking mode(-f)

### DIFF
--- a/src/Daemon/Daemon.cpp
+++ b/src/Daemon/Daemon.cpp
@@ -39,6 +39,7 @@
 #include <sys/time.h>
 #include <sys/types.h>
 #include <sys/poll.h>
+#include <sys/wait.h>
 #include <unistd.h>
 #include <signal.h>
 #include <string.h>
@@ -622,6 +623,7 @@ namespace usbguard
         const int signum = sigtimedwait(&mask, &info, &timeout);
 
         if (signum == SIGUSR1 && info.si_signo == SIGUSR1 && info.si_pid == pid) {
+          waitpid(pid, nullptr, 0);
           USBGUARD_LOG(Trace) << "Finished daemonization";
           exit(EXIT_SUCCESS);
         }


### PR DESCRIPTION

From the systemd.service man page regarding the ```Type=``` option:
```
      If set to forking, it is expected that the process configured with ExecStart= will call fork()
      as part of its start-up. The parent process is expected to exit when start-up is complete
      and all communication channels are set up. The child continues to run as the main service
      process, and the service manager will consider the unit started when the parent process
      exits. This is the behavior of traditional UNIX services. If this setting is used, it is
      recommended to also use the PIDFile= option, so that systemd can reliably identify the
      main process of the service. systemd will proceed with starting follow-up units as soon
      as the parent process exits.
```

With this in mind, the parent process should not exit until everything is fully initialized and the first child process exited. Otherwise, systemd could wrongly identify the PPID for the PID found in ```/run/usbguard.pid``` and due to this the following warning messages could be seen in the journal:
```
systemd: usbguard.service: Supervising process 1059 which is not our child. We'll most likely not notice when it exits.
```