### PR TITLE
scripts: Use bash-builtin `command -v` instead of external `which`

### DIFF
--- a/scripts/copr-build-srpm.sh
+++ b/scripts/copr-build-srpm.sh
@@ -17,8 +17,8 @@
 #
 # Authors: Daniel Kopecek <dkopecek@redhat.com>
 #
-CURL=$(which curl)
-JQ=$(which jq)
+CURL=$(command -v curl)
+JQ=$(command -v jq)
 
 if [ -z "$CURL" ]; then
   echo "Required curl command missing. Aborting."

--- a/scripts/usb-descriptor-collect.sh
+++ b/scripts/usb-descriptor-collect.sh
@@ -19,15 +19,15 @@
 #
 set -e -o pipefail
 
-SED=$(which sed)
-FIND=$(which find)
-LSUSB=$(which lsusb)
-SHA1SUM=$(which sha1sum)
-TAR=$(which tar)
-MKTEMP=$(which mktemp)
-CP=$(which cp)
-WC=$(which wc)
-RM=$(which rm)
+SED=$(command -v sed)
+FIND=$(command -v find)
+LSUSB=$(command -v lsusb)
+SHA1SUM=$(command -v sha1sum)
+TAR=$(command -v tar)
+MKTEMP=$(command -v mktemp)
+CP=$(command -v cp)
+WC=$(command -v wc)
+RM=$(command -v rm)
 
 TEMPDIR=$($MKTEMP -d --tmpdir usb-descriptor-collect.XXXXXX || (echo "Failed to create temporary directory"; exit 1))
 ROOTDIR="$TEMPDIR/usb-descriptor-data"

--- a/src/Tests/Source/CheckScripts/spell-check.sh
+++ b/src/Tests/Source/CheckScripts/spell-check.sh
@@ -24,8 +24,8 @@
 # check-path-exclude: doc/FOSDEM-2016/*
 #
 ##################
-ASPELL=$(which aspell)
-PANDOC=$(which pandoc)
+ASPELL=$(command -v aspell)
+PANDOC=$(command -v pandoc)
 
 SOURCE_FILEPATH="$1"
 

--- a/src/Tests/bash-testlib.sh
+++ b/src/Tests/bash-testlib.sh
@@ -82,7 +82,7 @@ function execute()
   local valgrind=""
 
   if [ -n "$USBGUARD_TESTS_VALGRIND" ]; then
-    valgrind="$(which valgrind)"
+    valgrind="$(command -v valgrind)"
   fi
 
   if [ "$USBGUARD_TESTS_VALGRIND" = "off" ]; then


### PR DESCRIPTION
`command -v` is a bash builtin and is a standardized version of `which`