### PR TITLE
Fix typo in CLI --help message: "privilges" -> "privileges"

### DIFF
--- a/scripts/usbguard-zsh-completion
+++ b/scripts/usbguard-zsh-completion
@@ -32,7 +32,7 @@ case $state in
       "generate-policy:Generate a rule set (policy) based on the connected USB devices."
       "watch:Watch for IPC interface events and print them to stdout."
       "read-descriptor:Read a USB descriptor from a file and print it in human-readable form."
-      "add-user:Add USBGuard IPC user/group (requires root privilges)"
+      "add-user:Add USBGuard IPC user/group (requires root privileges)"
       "remove-user:Remove USBGuard IPC user/group (requires root privileges)"
     )
     _describe -t subcommands 'usbguard subcommands' _subcommands && ret=0

--- a/src/CLI/usbguard.cpp
+++ b/src/CLI/usbguard.cpp
@@ -98,7 +98,7 @@ namespace usbguard
     stream << "  read-descriptor                Read a USB descriptor from a file and print it in human-readable form." <<
       std::endl;
     stream << std::endl;
-    stream << "  add-user <name>                Add USBGuard IPC user/group (requires root privilges)" << std::endl;
+    stream << "  add-user <name>                Add USBGuard IPC user/group (requires root privileges)" << std::endl;
     stream << "  remove-user <name>             Remove USBGuard IPC user/group (requires root privileges)" << std::endl;
     stream << std::endl;
   }


### PR DESCRIPTION
Signed-off-by: Christophe Vu-Brugier <cvubrugier@fastmail.fm>