### PR TITLE
Add missing .adoc files to the tarball

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -71,7 +71,10 @@ man_ROFF_FILES=\
 	$(man_ADOC_FILES:.adoc=.roff)
 
 EXTRA_DIST+=\
-	$(man_ADOC_FILES)
+	$(man_ADOC_FILES) \
+	doc/man/example-allow-device.adoc \
+	doc/man/example-initial-policy.adoc \
+	doc/man/footer.adoc
 
 CLEANFILES+=\
 	$(man_ROFF_FILES) \

--- a/doc/man/example-allow-device.adoc
+++ b/doc/man/example-allow-device.adoc
@@ -1,6 +1,6 @@
 ....
     # Allow a device by ID(it is the very first number from the list-devices command output)
-    $ sudo usbguard allow-device 10
+    $ usbguard allow-device 10
     # Allow all devices named "Dell Wired Multimedia Keyboard"
-    $ sudo usbguard allow-device name \"Dell Wired Multimedia Keyboard\"
+    $ usbguard allow-device name \"Dell Wired Multimedia Keyboard\"
 ....

--- a/doc/man/example-initial-policy.adoc
+++ b/doc/man/example-initial-policy.adoc
@@ -1,5 +1,5 @@
 ....
-    $ sudo usbguard generate-policy > rules.conf
+    $ usbguard generate-policy > rules.conf
     $ vi rules.conf
     (review/modify the rule set)
     $ sudo install -m 0600 -o root -g root rules.conf /etc/usbguard/rules.conf


### PR DESCRIPTION
If one attempted to build usbguard from the tarball, some documentation related files would be left out. The patch resolves this issue.