### PR TITLE
Specify what happens when neither RuleFile nor RuleFolder is set

### DIFF
--- a/src/Daemon/RuleSetFactory.cpp
+++ b/src/Daemon/RuleSetFactory.cpp
@@ -76,7 +76,7 @@ namespace usbguard
       }
 
       if (ruleSet.empty()) {
-        USBGUARD_LOG(Warning) << "RuleFile not set; Modification of the permanent policy won't be possible.";
+        USBGUARD_LOG(Warning) << "Neither RuleFile nor RuleFolder are set; Modification of the permanent policy won't be possible.";
         ruleSet = generateDefaultRuleSet();
       }
 


### PR DESCRIPTION
Precisely specify what happens when neither RuleFile nor RuleFolder is set. Whilst this is an extraordinary use case, some might be confused in case they encounter the issue.

Reproduction of the issue is straightforward: remove RuleFile and RuleFolder from the config.