### PR TITLE
Harden service file: Set OOMScoreAdjust to -1000

### DIFF
--- a/usbguard.service.in
+++ b/usbguard.service.in
@@ -4,6 +4,7 @@ Wants=systemd-udevd.service local-fs.target
 Documentation=man:usbguard-daemon(8)
 
 [Service]
+OOMScoreAdjust=-1000
 AmbientCapabilities=
 CapabilityBoundingSet=CAP_CHOWN CAP_FOWNER CAP_AUDIT_WRITE
 DevicePolicy=closed


### PR DESCRIPTION
From the ```systemd.exec(5)``` man page:
```
OOMScoreAdjust=
      Sets the adjustment value for the Linux kernel's Out-Of-Memory (OOM) killer score for
      executed processes. Takes an integer between -1000 (to disable OOM killing of processes of
      this unit) and 1000 (to make killing of processes of this unit under memory pressure very
      likely). 
```

The out-of-memory killer in the kernel can easily kill the usbguard-daemon for example when unauthorized process creates many small processes, which causes the OOM algorithm to see usbguard-daemon as the best candidate to be killed, instead of aiming 
at some of those unprivileged processes. I have not seen an example of this in practice, but I think it would be good to include.