### PR TITLE
Add "--version" option to the usbguard CLI

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -433,7 +433,9 @@ usbguard_SOURCES=\
 	src/CLI/usbguard-add-user.cpp \
 	src/CLI/usbguard-add-user.hpp \
 	src/CLI/usbguard-remove-user.cpp \
-	src/CLI/usbguard-remove-user.hpp
+	src/CLI/usbguard-remove-user.hpp \
+	src/CLI/usbguard-print-version.cpp \
+	src/CLI/usbguard-print-version.hpp
 
 usbguard_CXXFLAGS=\
 	$(PTHREAD_CFLAGS)

--- a/scripts/bash_completion/usbguard
+++ b/scripts/bash_completion/usbguard
@@ -251,7 +251,7 @@ _usbguard() {
     # If there was no positional argument provided yet, complete commands
     if [[ $args -eq 1 ]]; then
         opts="get-parameter set-parameter list-devices allow-device block-device reject-device list-rules append-rule"
-        opts="${opts} remove-rule generate-policy watch read-descriptor add-user remove-user"
+        opts="${opts} remove-rule generate-policy watch read-descriptor add-user remove-user --version"
 
     else
         opts='-h --help'

--- a/src/CLI/usbguard-print-version.cpp
+++ b/src/CLI/usbguard-print-version.cpp
@@ -1,0 +1,83 @@
+//
+// Copyright (C) 2022 Red Hat, Inc.
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+// Authors: Attila Lakatos <alakatos@redhat.com>
+//
+#ifdef HAVE_BUILD_CONFIG_H
+  #include <build-config.h>
+#endif
+
+#include "usbguard.hpp"
+#include "usbguard-print-version.hpp"
+
+#include "usbguard/IPCClient.hpp"
+
+#include <iostream>
+#include <map>
+#include <vector>
+
+
+namespace usbguard
+{
+  static std::string toHumanReadable(const int enabled)
+  {
+    return enabled ? "enabled" : "disabled";
+  }
+
+  int usbguard_print_version(__attribute__((unused)) int argc, __attribute__((unused)) char* argv[])
+  {
+    if (argc != 1) {
+      return EXIT_FAILURE;
+    }
+
+    int audit = 0, libcapng = 0, seccomp = 0, systemd = 0, umockdev = 0;
+    std::string crypto;
+#ifdef HAVE_LINUX_AUDIT
+    audit = 1;
+#endif
+#ifdef HAVE_LIBCAPNG
+    libcapng = 1;
+#endif
+#ifdef HAVE_SECCOMP
+    seccomp = 1;
+#endif
+#ifdef SYSTEMD_SUPPORT_ENABLED
+    systemd = 1;
+#endif
+#ifdef HAVE_UMOCKDEV
+    umockdev = 1;
+#endif
+#ifdef USBGUARD_USE_LIBGCRYPT
+    crypto = "libgcrypt";
+#elif USBGUARD_USE_LIBSODIUM
+    crypto = "libsodium";
+#elif USBGUARD_USE_OPENSSL
+    crypto = "openssl";
+#else
+    crypto = "unknown";
+#endif
+    std::cout << "usbguard " << PACKAGE_VERSION << " compiled with:" << std::endl;
+    std::cout << "  Linux audit support:    " << toHumanReadable(audit) << std::endl;
+    std::cout << "  Libcapng support:       " << toHumanReadable(libcapng) << std::endl;
+    std::cout << "  Seccomp support:        " << toHumanReadable(seccomp) << std::endl;
+    std::cout << "  Systemd support:        " << toHumanReadable(systemd) << std::endl;
+    std::cout << "  Umockdev support:       " << toHumanReadable(umockdev) << std::endl;
+    std::cout << "  Crypto backend library: " << crypto << std::endl;
+    return EXIT_SUCCESS;
+  }
+} /* namespace usbguard */
+
+/* vim: set ts=2 sw=2 et */

--- a/src/CLI/usbguard-print-version.hpp
+++ b/src/CLI/usbguard-print-version.hpp
@@ -1,0 +1,29 @@
+//
+// Copyright (C) 2022 Red Hat, Inc.
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+// Authors: Attila Lakatos <alakatos@redhat.com>
+//
+#pragma once
+#ifdef HAVE_BUILD_CONFIG_H
+  #include <build-config.h>
+#endif
+
+namespace usbguard
+{
+  int usbguard_print_version(int argc, char** argv);
+} /* namespace usbguard */
+
+/* vim: set ts=2 sw=2 et */

--- a/src/CLI/usbguard.cpp
+++ b/src/CLI/usbguard.cpp
@@ -52,6 +52,7 @@
 #include "usbguard-read-descriptor.hpp"
 #include "usbguard-add-user.hpp"
 #include "usbguard-remove-user.hpp"
+#include "usbguard-print-version.hpp"
 
 namespace usbguard
 {
@@ -71,7 +72,8 @@ namespace usbguard
     { "watch", &usbguard_watch },
     { "read-descriptor", &usbguard_read_descriptor },
     { "add-user", &usbguard_add_user },
-    { "remove-user", &usbguard_remove_user }
+    { "remove-user", &usbguard_remove_user },
+    { "--version", &usbguard_print_version }
   };
 
   static void showTopLevelHelp(std::ostream& stream = std::cout)

--- a/src/Tests/LDAP/ansible/roles/bennojoy.openldap_server/tasks/main.yml
+++ b/src/Tests/LDAP/ansible/roles/bennojoy.openldap_server/tasks/main.yml
@@ -1,3 +1,3 @@
 ---
-- include: install_ldap.yml
-- include: configure_ldap.yml
+- include_tasks: install_ldap.yml
+- include_tasks: configure_ldap.yml


### PR DESCRIPTION
Running ```usbguard --version``` should help us handle fixes and issues more easily in the future. By doing so, it's easier to track down which options have been enabled during build time. Fixes #570

Any suggestions on what else to display are welcomed.