### PR TITLE
Store permanent rules even if RuleFile is not set but RuleFolder is.

### DIFF
--- a/doc/man/usbguard-daemon.conf.5.adoc
+++ b/doc/man/usbguard-daemon.conf.5.adoc
@@ -27,7 +27,12 @@ It may be overridden using the *-c* command-line option, see *usbguard-daemon*(8
     behave like any other standard Linux daemon therefore it loads rule files in
     alpha-numeric order. File names inside `RuleFolder` directory should start
     with a two-digit number prefix indicating the position, in which the rules
-    are scanned by the daemon.
+    are scanned by the daemon. Using RuleFile and RuleFolder at the same time is
+    permitted. However, modification of the permanent policy is not possible if
+    one of the following conditions are met:
+    ** Neither RuleFile nor RuleFolder are specified.
+    ** RuleFile is not specified, RuleFolder is but it does not contain any files,
+       where we could save permanent rules.
 
 *ImplicitPolicyTarget*='target'::
     How to treat USB devices that don't match any rule in the policy. Target

--- a/src/Daemon/Daemon.cpp
+++ b/src/Daemon/Daemon.cpp
@@ -758,7 +758,7 @@ namespace usbguard
     /* TODO: reevaluate the firewall rules for all active devices */
     const uint32_t id = _policy.appendRule(rule, parent_id);
 
-    if (_config.hasSettingValue("RuleFile") && permanent) {
+    if ((_config.hasSettingValue("RuleFile") || _config.hasSettingValue("RuleFolder")) && permanent) {
       _policy.save();
     }
 
@@ -771,7 +771,7 @@ namespace usbguard
     USBGUARD_LOG(Trace) << "id=" << id;
     _policy.removeRule(id);
 
-    if (_config.hasSettingValue("RuleFile")) {
+    if (_config.hasSettingValue("RuleFile") || _config.hasSettingValue("RuleFolder")) {
       _policy.save();
     }
   }

--- a/src/Daemon/RuleSetFactory.cpp
+++ b/src/Daemon/RuleSetFactory.cpp
@@ -75,8 +75,24 @@ namespace usbguard
         }
       }
 
+      /*
+       * This means one of the following:
+       *  - Neither RuleFile nor RuleFolder are specified
+       *  - RuleFile not specified, RuleFolder is but it does not contain any files,
+       *    where we could save permanent rules
+       */
       if (ruleSet.empty()) {
-        USBGUARD_LOG(Warning) << "Neither RuleFile nor RuleFolder are set; Modification of the permanent policy won't be possible.";
+        std::string msg;
+
+        if (ns.getRulesPath().empty() && ns.getRulesDirPath().empty()) {
+          msg = "Neither RuleFile nor RuleFolder are set.";
+        }
+        else {
+          msg = "RuleFile is not set, RuleFolder is but it does not contain any rule files.";
+        }
+
+        USBGUARD_LOG(Warning) << "Modification of the permanent policy won't be possible."
+          << " Reason: " << msg;
         ruleSet = generateDefaultRuleSet();
       }
 


### PR DESCRIPTION
This PR fixes the situation when appending permanent rules is not working, especially when RuleFile is not set but RuleFolder is. Documentation was extended as well to comply with the latest changes.
Fixes #577

