### PR TITLE
Fix compile with GCC 13

### DIFF
--- a/src/Library/Base64.hpp
+++ b/src/Library/Base64.hpp
@@ -24,6 +24,7 @@
 
 #include <string>
 #include <cstddef>
+#include <cstdint>
 
 namespace usbguard
 {


### PR DESCRIPTION
This is needed for https://gcc.gnu.org/gcc-13/porting_to.html
