### PR TITLE
include missing <cstdint>

### DIFF
--- a/src/Library/Base64.cpp
+++ b/src/Library/Base64.cpp
@@ -22,7 +22,6 @@
 
 #include "Base64.hpp"
 #include <stdexcept>
-#include <cstdint>
 
 namespace usbguard
 {

--- a/src/Library/Base64.hpp
+++ b/src/Library/Base64.hpp
@@ -23,6 +23,7 @@
 #endif
 
 #include <string>
+#include <cstdint>
 #include <cstddef>
 
 namespace usbguard


### PR DESCRIPTION
gcc 13 moved some includes around and as a result <cstdint> is no longer transitively included [1]. Explicitly include it for uint8_t.

[1] https://gcc.gnu.org/gcc-13/porting_to.html#header-dep-changes

Signed-off-by: Khem Raj <raj.khem@gmail.com>