### PR TITLE
ruleset: detect integer overflow of the ID and bail out

### DIFF
--- a/src/Library/public/usbguard/RuleSet.cpp
+++ b/src/Library/public/usbguard/RuleSet.cpp
@@ -223,7 +223,13 @@ namespace usbguard
 
   uint32_t RuleSet::assignID()
   {
-    return _id_next++;
+    const auto next_id = _id_next + 1;
+    if (next_id >= Rule::LastID) [[unlikely]]
+        {
+            throw std::out_of_range("Rule ID too high");
+        }
+    _id_next = next_id;
+    return next_id;
   }
 
   void RuleSet::setWritable()


### PR DESCRIPTION
The check is semantically correct, because some IDs are reserved. Here, we exploit the fact that the LastID is defined to be max_int-2, so when we increment _id_next often enough, we will eventually reach the reserved LastID. If that ID is reached, we bail out to prevent further damage. We could have used the `__builtin_add_overflow` GCC extension but I don't know how compatible it is. Besides, we probably want to prevent the ID spilling into the reserved LastID anyway.

The daemon logs the exception and keeps running. But it appears dysfunctional, i.e. does not notice new device let alone authorise any. That may or may not be the desired behaviour. But it serves as base for discussion and is probably more desired than the behaviour with the overflow.

To test the change, I have the following line in the assignID function:

```
    const auto base = 1 ? (Rule::LastID - 10) : 0 ;
    const auto next_id = _id_next + 1  +  base;
    USBGUARD_LOG(Debug) << "Base: " << 0 << ", Current RuleID: " << _id_next << ", next " << next_id << ", (" << Rule::LastID << ")";
    ...
    _id_next = next_id - base;

```