### PR TITLE
Enable RuleFolder by default

### DIFF
--- a/usbguard-daemon.conf.in
+++ b/usbguard-daemon.conf.in
@@ -24,7 +24,7 @@ RuleFile=%sysconfdir%/usbguard/rules.conf
 #
 # RuleFolder=/path/to/rulesfolder/
 #
-#RuleFolder=%sysconfdir%/usbguard/rules.d/
+RuleFolder=%sysconfdir%/usbguard/rules.d/
 
 
 


### PR DESCRIPTION
I don't really know why this was not enabled by default in the first place but this is really useful, also to extend it with distro-specific configuration without touching the upstream files themselves