### PR TITLE
Bump c++ version to 20

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -54,7 +54,7 @@ AX_CHECK_COMPILE_FLAG([-Wno-implicit-fallthrough],
 #
 # Final project CXXFLAGS are set after configure checks.
 #
-CXXFLAGS="-std=c++17 $EXTERNAL_CXXFLAGS"
+CXXFLAGS="-std=c++20 $EXTERNAL_CXXFLAGS"
 CFLAGS="-std=c99 $EXTERNAL_CFLAGS"
 CPPFLAGS="-DHAVE_BUILD_CONFIG_H $EXTERNAL_CPPFLAGS"
 
@@ -394,7 +394,7 @@ if test "x$with_bundled_catch" = xyes; then
 	catch_summary="bundled; $catch_CFLAGS $catch_LIBS"
 else
 	SAVE_CPPFLAGS=$CPPFLAGS
-	CPPFLAGS="-std=c++17 $CPPFLAGS -I/usr/include/catch2"
+	CPPFLAGS="-std=c++20 $CPPFLAGS -I/usr/include/catch2"
 	AC_LANG_PUSH([C++])
 	AC_CHECK_HEADER([catch.hpp], [], [AC_MSG_FAILURE(catch.hpp not found or not usable. Re-run with --with-bundled-catch to use the bundled library.)])
 	AC_LANG_POP
@@ -451,7 +451,7 @@ AC_SUBST([pegtl_AC_CFLAGS])
 AC_SUBST([pegtl_LIBS])
 
 SAVE_CPPFLAGS=$CPPFLAGS
-CPPFLAGS="-std=c++17 $CPPFLAGS $pegtl_AC_CFLAGS"
+CPPFLAGS="-std=c++20 $CPPFLAGS $pegtl_AC_CFLAGS"
 AC_LANG_PUSH([C++])
 AC_CHECK_HEADER([tao/pegtl.hpp],
 		[AC_DEFINE([HAVE_TAO_PEGTL_HPP], [1], [PEGTL header file with .hpp extension is present])],

--- a/src/Library/public/usbguard/RuleSet.cpp
+++ b/src/Library/public/usbguard/RuleSet.cpp
@@ -224,10 +224,11 @@ namespace usbguard
   uint32_t RuleSet::assignID()
   {
     const auto next_id = _id_next + 1;
-    if (next_id >= Rule::LastID) [[unlikely]]
-        {
-            throw std::out_of_range("Rule ID too high");
-        }
+
+    if (next_id >= Rule::LastID)
+      [[unlikely]] {
+      throw std::out_of_range("Rule ID too high");
+    }
     _id_next = next_id;
     return next_id;
   }

--- a/src/Tests/UseCase/001_cli_policy.sh
+++ b/src/Tests/UseCase/001_cli_policy.sh
@@ -43,17 +43,17 @@ function test_cli_policy()
 {
   set -e
   sleep 4
-  
+
   c=$(${USBGUARD} list-rules | wc -l)
   # TODO [ $c -eq 0 ] || return 1
 
-  ${USBGUARD} append-rule block
-  
+  ruleID=`${USBGUARD} append-rule block`
+
   c=$(${USBGUARD} list-rules | wc -l)
   # TODO [ $c -eq 1 ] || return 1
 
-  ${USBGUARD} remove-rule 1
-  
+  ${USBGUARD} remove-rule ${ruleID}
+
   c=$(${USBGUARD} list-rules | wc -l)
   # TODO [ $c -eq 0 ] || return 1
 


### PR DESCRIPTION
Currently, the CI is failing because it's not able to parse the new `[[ unlikely ]]` attribute. I am not aware of any other new features the project uses but it might use in the future. We can either remove the attribute or switch to c++20.

Considering that c++20 has been out for a while and compilers already support it, I think it's safe to do.
More info: https://en.cppreference.com/w/cpp/20
