### PR TITLE
[DRAFT] Fix regression: specifying IPC privileges using UID

### DIFF
--- a/src/Common/Utility.cpp
+++ b/src/Common/Utility.cpp
@@ -543,7 +543,22 @@ namespace usbguard
     return rulefile_list;
   }
 
-  bool isValidName(const std::string& name)
+  static bool isValidUID(const std::string& uid)
+  {
+    if (uid.empty()) {
+      return false;
+    }
+
+    for (char c : uid) {
+      if (!std::isdigit(c)) {
+        return false;
+      }
+    }
+
+    return true;
+  }
+
+  static bool isValidName(const std::string& name)
   {
     const char* s = name.data();
 
@@ -566,6 +581,10 @@ namespace usbguard
     }
 
     return true;
+  }
+
+  bool isValidNameOrUID(const std::string& input) {
+    return isValidName(input) || isValidUID(input);
   }
 
 } /* namespace usbguard */

--- a/src/Common/Utility.hpp
+++ b/src/Common/Utility.hpp
@@ -319,12 +319,11 @@ namespace usbguard
   /**
    * @brief Checks whether a given name is a valid group/user name
    *
-   * User/group names must match [A-Za-z_][A-Za-z0-9_-]*[$]
    *
    * @param name Name to check
    * @return True if given name is valid, false otherwise
    */
-  bool isValidName(const std::string& name);
+  bool isValidNameOrUID(const std::string& name);
 
 } /* namespace usbguard */
 

--- a/src/Library/public/usbguard/IPCServer.cpp
+++ b/src/Library/public/usbguard/IPCServer.cpp
@@ -36,8 +36,8 @@ namespace usbguard
       throw Exception("IPC access control", "name too long", name);
     }
 
-    if (!isValidName(name)) {
-      throw Exception("IPC access control", "invalid name format", name);
+	if (!isValidNameOrUID(name)) {
+      throw Exception("IPC access control", "invalid name or UID format", name);
     }
   }
 

--- a/src/Library/public/usbguard/IPCServer.hpp
+++ b/src/Library/public/usbguard/IPCServer.hpp
@@ -50,9 +50,9 @@ namespace usbguard
     /**
      * @brief Checks whether given name is a valid access control name.
      *
-     * Name is a valid access control name iff:
+     * Name is a valid access control name if:
      *  1. it is not longer then 32 characters
-     *  2. it matches regex [A-Za-z_][A-Za-z0-9_-]*[$]
+     *  2. it is aligned with the syntax of useradd(8)
      *
      * @param name Name to be verified.
      * @throw Exception If \p name is not a valid access control name.


### PR DESCRIPTION
Recently, I came across an observation where it's not possible to specify the IPCAccessControlFiles using an `UID` instead of `username`/`groupname`. For example:
```
usbguard add-user 1000 --device list
```

Expected results: user with ID of 1000 can list devices
Actual results: `ERROR: IPC access control: invalid name format: 1002`

That is because the `isValidName()` function does not allow having 'digit-only' names. I haven't experimented with the patch, will leave it here for discussion.

This was working in the past. Not sure if anyone is using it like this, so another possibility could be to leave it as it is and modify the documentation.