### PR TITLE
Ignore whitespace around rule

### DIFF
--- a/src/Library/RuleParser/Grammar.hpp
+++ b/src/Library/RuleParser/Grammar.hpp
@@ -214,13 +214,14 @@ namespace usbguard
       : seq<target,
         opt<plus<ascii::blank>, device_id>,
         opt<plus<ascii::blank>, list<rule_attributes, plus<ascii::blank>>>,
-        opt<comment>> {};
+        opt<comment>,
+        star<ascii::blank>> {};
 
     /*
      * Grammar entry point
      */
     struct rule_grammar
-      : until<eof, must<sor<comment, rule>>> {};
+      : seq<star<ascii::blank>, opt<sor<comment, rule>>, must<eof>> {};
   } /* namespace RuleParser */
 } /* namespace usbguard */
 

--- a/src/Tests/Rules/test-rules.file
+++ b/src/Tests/Rules/test-rules.file
@@ -9,3 +9,6 @@ reject with-interface one-of { e5:*:* 2A:*:* AC:c7:* 4B:*:* f2:*:* }  if equals-
 
 reject with-interface one-of { e6:*:* } # comment about this rule
  # reject with-interface one-of { e6:*:* }
+
+# Ignore whitespace around rule
+ reject with-interface one-of { e6:*:* } 


### PR DESCRIPTION
Fixes #571 

Allow rules in 'rules.conf' to start and end with spaces.
It also allowed lines with only spaces.

```rules.conf
$ cat -A rules.conf
allow $
 $
```

I would like to allow these characters because they are invisible, but I would like to hear your opinion about lines starting with spaces.

```rules.conf
$ cat -A rules.conf
 allow$
```