### PR TITLE
Add usbguard-tmpfles.conf

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -90,8 +90,8 @@ $(top_builddir)/%.roff: %.adoc
 	$(INSTALL) -m 644 $(top_builddir)/$(@:.roff=) $(top_builddir)/$@
 endif
 
-install-data-hook: install-daemon-conf install-systemd-service install-data-dbus
-uninstall-hook: uninstall-daemon-conf uninstall-systemd-service uninstall-data-dbus
+install-data-hook: install-daemon-conf install-systemd-service install-data-dbus install-tmpfiles
+uninstall-hook: uninstall-daemon-conf uninstall-systemd-service uninstall-data-dbus uninstall-tmpfiles
 
 CLEANFILES+=\
 	$(top_builddir)/usbguard-daemon.conf
@@ -105,6 +105,15 @@ usbguard-daemon.conf: $(top_builddir)/usbguard-daemon.conf.in
 usbguard_confdir= $(sysconfdir)/usbguard
 
 distuninstallcheck_listfiles= find . -type f ! -name rules.conf -print
+
+EXTRA_DIST+=usbguard-tmpfiles.conf
+
+install-tmpfiles:
+	mkdir -p ${DESTDIR}$(prefix)/lib/tmpfiles.d/
+	$(INSTALL_DATA) -m 640 ${srcdir}/usbguard-tmpfiles.conf ${DESTDIR}$(prefix)/lib/tmpfiles.d/usbguard.conf
+
+uninstall-tmpfiles:
+	rm ${DESTDIR}$(prefix)/lib/tmpfiles.d/usbguard.conf
 
 install-daemon-conf: $(top_builddir)/usbguard-daemon.conf
 	$(MKDIR_P) $(DESTDIR)/$(usbguard_confdir)

--- a/usbguard-tmpfiles.conf
+++ b/usbguard-tmpfiles.conf
@@ -1,0 +1,1 @@
+d /var/log/usbguard 0700 root root - -


### PR DESCRIPTION
At boot time, systemd‑tmpfiles processes this file and creates /var/log/usbguard so that the usbguard service can start successfully.

https://issues.redhat.com/browse/OCPBUGS-49675
