### PR TITLE
Modified USBguard append-rule to add support to the beginning of the …

### DIFF
--- a/src/Library/public/usbguard/Policy.cpp
+++ b/src/Library/public/usbguard/Policy.cpp
@@ -60,6 +60,17 @@ namespace usbguard
     USBGUARD_LOG(Trace) << "parent_id=" << parent_id;
     auto rule = std::make_shared<Rule>(_rule);
 
+    if (parent_id == 0) {
+      auto ruleset = _rulesets_ptr.front();
+
+      if (rule->getRuleID() == Rule::DefaultID) {
+        assignID(rule);
+      }
+
+      auto rules = ruleset->getRules();
+      return ruleset->appendRule(*rule， 0);
+    }
+
     // If the parent_id is set to Rule::LastID then we get the the ID of the last rule in rulesets
     if (parent_id == Rule::LastID) {
       auto ruleset = _rulesets_ptr.back();


### PR DESCRIPTION
Modified USBguard append-rule to add support to the beginning of the configuration file (-a 0 command)
this cmd will failed：
# usbguard append-rule -a 0 "allow 000e:1923"
IPC ERROR: request id=1: Policy append: rule: Invalid parent ID

from RuleSet::appendRule func，it show can support ID 0  to Add to the head of a rule
![usbguard-append-rule-a-0](https://github.com/user-attachments/assets/ee990fac-7602-4e54-a0ab-60534e7eb954)

