### PR TITLE
Restore permissions on /var/log/usbguard dir

### DIFF
--- a/usbguard-tmpfiles.conf
+++ b/usbguard-tmpfiles.conf
@@ -1,1 +1,1 @@
-d /var/log/usbguard 0700 root root - -
+d /var/log/usbguard 0755 root root - -


### PR DESCRIPTION
In a recent patch, the permissions of the `/var/log/usbguard` file were unintentionally changed. This caused issues with tools like `rpm`, particularly when verifying whether the file provided by a package had been modified.
Before:
```
rpm -V usbguard
.M.......    /var/log/usbguard
```