### PR TITLE
Docker: Bump to Alpine 3.21 to fix Alpine CI (fixes #655)

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -32,7 +32,7 @@ jobs:
       fail-fast: false
       matrix:
         linux_distro:
-        - Alpine Linux 3.20  # with musl
+        - Alpine Linux 3.21  # with musl
         - CentOS 8.2         # with GCC 8.5.0
         - Debian Buster with GCC 9.2  # stock buster has GCC 8.3
         - Ubuntu 22.04       # because super popular

--- a/scripts/docker/build_on_alpine_linux_3_21.Dockerfile
+++ b/scripts/docker/build_on_alpine_linux_3_21.Dockerfile
@@ -14,7 +14,7 @@
 ## You should have received a copy of the GNU General Public License
 ## along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-FROM alpine:3.20
+FROM alpine:3.21
 RUN echo '@edge-testing https://dl-cdn.alpinelinux.org/alpine/edge/testing' >> /etc/apk/repositories \
         && \
     apk add --update \


### PR DESCRIPTION
Fixes #655

CC @Cropi 