### PR TITLE
tests: add support for Catch2 v3

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -396,10 +396,15 @@ else
 	SAVE_CPPFLAGS=$CPPFLAGS
 	CPPFLAGS="-std=c++17 $CPPFLAGS -I/usr/include/catch2"
 	AC_LANG_PUSH([C++])
-	AC_CHECK_HEADER([catch.hpp], [], [AC_MSG_FAILURE(catch.hpp not found or not usable. Re-run with --with-bundled-catch to use the bundled library.)])
+	AC_CHECK_HEADER([catch_test_macros.hpp],
+	[catch_CFLAGS="-I/usr/include/catch2 -DHAVE_CATCH2_V3"
+	catch_LIBS="-lCatch2Main -lCatch2"],
+        [AC_CHECK_HEADER([catch.hpp],
+	[catch_CFLAGS="-I/usr/include/catch2"
+	catch_LIBS=""],
+        [AC_MSG_FAILURE(Catch2 not found or not usable. Re-run with --with-bundled-catch to use the bundled library.)]
+        )])
 	AC_LANG_POP
-	catch_CFLAGS="-I/usr/include/catch2"
-	catch_LIBS=""
 	CPPFLAGS=$SAVE_CPPFLAGS
 	catch_summary="system-wide; $catch_CFLAGS $catch_LIBS"
 fi

--- a/src/Tests/Makefile.am
+++ b/src/Tests/Makefile.am
@@ -123,6 +123,7 @@ test_unit_CXXFLAGS=\
 
 test_unit_LDADD=\
 	$(top_builddir)/libusbguard.la \
+	$(catch_LIBS) \
 	$(PTHREAD_LIBS)
 
 test_unit_LDFLAGS=\
@@ -140,5 +141,6 @@ test_regression_CXXFLAGS=\
 
 test_regression_LDADD=\
 	$(top_builddir)/libusbguard.la \
+	$(catch_LIBS) \
 	$(PTHREAD_LIBS)
 

--- a/src/Tests/Regression/github-PR209-config-parser.cpp
+++ b/src/Tests/Regression/github-PR209-config-parser.cpp
@@ -18,7 +18,11 @@
 //
 
 #include "usbguard/ConfigFile.hpp"
-#include <catch.hpp>
+#ifdef HAVE_CATCH2_V3
+  #include <catch_test_macros.hpp>
+#else
+  #include <catch.hpp>
+#endif
 
 #include <sys/stat.h>
 #include <sys/types.h>

--- a/src/Tests/Regression/test_Rule_ghi113.cpp
+++ b/src/Tests/Regression/test_Rule_ghi113.cpp
@@ -18,7 +18,11 @@
 //
 #include "usbguard/Rule.hpp"
 
-#include <catch.hpp>
+#ifdef HAVE_CATCH2_V3
+  #include <catch_test_macros.hpp>
+#else
+  #include <catch.hpp>
+#endif
 
 using namespace usbguard;
 

--- a/src/Tests/Regression/test_Rule_ghi247.cpp
+++ b/src/Tests/Regression/test_Rule_ghi247.cpp
@@ -19,7 +19,11 @@
 #include "usbguard/Rule.hpp"
 #include "usbguard/Rule.hpp"
 
-#include <catch.hpp>
+#ifdef HAVE_CATCH2_V3
+  #include <catch_test_macros.hpp>
+#else
+  #include <catch.hpp>
+#endif
 
 using namespace usbguard;
 

--- a/src/Tests/Regression/test_Rule_ghi37.cpp
+++ b/src/Tests/Regression/test_Rule_ghi37.cpp
@@ -18,7 +18,11 @@
 //
 #include "usbguard/Rule.hpp"
 
-#include <catch.hpp>
+#ifdef HAVE_CATCH2_V3
+  #include <catch_test_macros.hpp>
+#else
+  #include <catch.hpp>
+#endif
 
 using namespace usbguard;
 

--- a/src/Tests/Unit/test_Base64.cpp
+++ b/src/Tests/Unit/test_Base64.cpp
@@ -16,7 +16,11 @@
 //
 // Authors: Daniel Kopecek <dkopecek@redhat.com>
 //
-#include <catch.hpp>
+#ifdef HAVE_CATCH2_V3
+  #include <catch_test_macros.hpp>
+#else
+  #include <catch.hpp>
+#endif
 #include <Base64.cpp>
 
 using namespace usbguard;

--- a/src/Tests/Unit/test_IPCServer_AccessControl.cpp
+++ b/src/Tests/Unit/test_IPCServer_AccessControl.cpp
@@ -18,7 +18,11 @@
 //
 #include "usbguard/IPCServer.hpp"
 
-#include <catch.hpp>
+#ifdef HAVE_CATCH2_V3
+  #include <catch_test_macros.hpp>
+#else
+  #include <catch.hpp>
+#endif
 #include <sstream>
 
 using namespace usbguard;

--- a/src/Tests/Unit/test_Rule.cpp
+++ b/src/Tests/Unit/test_Rule.cpp
@@ -18,7 +18,11 @@
 //
 #include "usbguard/Rule.hpp"
 
-#include <catch.hpp>
+#ifdef HAVE_CATCH2_V3
+  #include <catch_test_macros.hpp>
+#else
+  #include <catch.hpp>
+#endif
 
 using namespace usbguard;
 

--- a/src/Tests/Unit/test_RuleAttribute_id.cpp
+++ b/src/Tests/Unit/test_RuleAttribute_id.cpp
@@ -18,7 +18,11 @@
 //
 #include "usbguard/Rule.hpp"
 
-#include <catch.hpp>
+#ifdef HAVE_CATCH2_V3
+  #include <catch_test_macros.hpp>
+#else
+  #include <catch.hpp>
+#endif
 
 using namespace usbguard;
 

--- a/src/Tests/Unit/test_RuleParser.cpp
+++ b/src/Tests/Unit/test_RuleParser.cpp
@@ -18,7 +18,11 @@
 //
 #include "usbguard/Rule.hpp"
 
-#include <catch.hpp>
+#ifdef HAVE_CATCH2_V3
+  #include <catch_test_macros.hpp>
+#else
+  #include <catch.hpp>
+#endif
 
 using namespace usbguard;
 

--- a/src/Tests/Unit/test_UEvent.cpp
+++ b/src/Tests/Unit/test_UEvent.cpp
@@ -16,7 +16,11 @@
 //
 // Authors: Daniel Kopecek <dkopecek@redhat.com>
 //
-#include <catch.hpp>
+#ifdef HAVE_CATCH2_V3
+  #include <catch_test_macros.hpp>
+#else
+  #include <catch.hpp>
+#endif
 #include <UEvent.cpp>
 
 using namespace usbguard;

--- a/src/Tests/Unit/test_UEventParser.cpp
+++ b/src/Tests/Unit/test_UEventParser.cpp
@@ -16,7 +16,11 @@
 //
 // Authors: Daniel Kopecek <dkopecek@redhat.com>
 //
-#include <catch.hpp>
+#ifdef HAVE_CATCH2_V3
+  #include <catch_test_macros.hpp>
+#else
+  #include <catch.hpp>
+#endif
 #include <UEventParser.cpp>
 
 using namespace usbguard;

--- a/src/Tests/Unit/test_UMockdevDeviceDefinition.cpp
+++ b/src/Tests/Unit/test_UMockdevDeviceDefinition.cpp
@@ -16,7 +16,11 @@
 //
 // Authors: Daniel Kopecek <dkopecek@redhat.com>
 //
-#include <catch.hpp>
+#ifdef HAVE_CATCH2_V3
+  #include <catch_test_macros.hpp>
+#else
+  #include <catch.hpp>
+#endif
 #include <UMockdevDeviceDefinition.cpp>
 
 #include "test_UMockdevDeviceDefinition.data.hpp"

--- a/src/Tests/Unit/test_Utility.cpp
+++ b/src/Tests/Unit/test_Utility.cpp
@@ -16,7 +16,11 @@
 //
 // Authors: Daniel Kopecek <dkopecek@redhat.com>
 //
-#include <catch.hpp>
+#ifdef HAVE_CATCH2_V3
+  #include <catch_test_macros.hpp>
+#else
+  #include <catch.hpp>
+#endif
 #include <Common/Utility.cpp>
 
 using namespace usbguard;

--- a/src/Tests/main.cpp
+++ b/src/Tests/main.cpp
@@ -16,7 +16,11 @@
 //
 // Authors: Daniel Kopecek <dkopecek@redhat.com>
 //
-#define CATCH_CONFIG_MAIN
-#include <catch.hpp>
+#ifdef HAVE_CATCH2_V3
+  #include <catch_test_macros.hpp>
+#else
+  #define CATCH_CONFIG_MAIN
+  #include <catch.hpp>
+#endif
 
 /* vim: set ts=2 sw=2 et */


### PR DESCRIPTION
Catch2 v3 no longer has a monolithic <catch.hpp> and also requires linking against compiled libraries:

https://github.com/catchorg/Catch2/blob/v3.0.1/docs/migrate-v2-to-v3.md

This allows either v2 or v3 of system-installed Catch2 to be used.

Fixes: #549
