### PR TITLE
Added CAP_DAC_READ_SEARCH capability to systemd service file

### DIFF
--- a/usbguard.service.in
+++ b/usbguard.service.in
@@ -6,7 +6,7 @@ Documentation=man:usbguard-daemon(8)
 [Service]
 OOMScoreAdjust=-1000
 AmbientCapabilities=
-CapabilityBoundingSet=CAP_CHOWN CAP_FOWNER CAP_AUDIT_WRITE
+CapabilityBoundingSet=CAP_CHOWN CAP_FOWNER CAP_AUDIT_WRITE CAP_DAC_READ_SEARCH
 DevicePolicy=closed
 ExecStart=%sbindir%/usbguard-daemon -f -s -c %sysconfdir%/usbguard/usbguard-daemon.conf
 IPAddressDeny=any


### PR DESCRIPTION
With the old CapabilityBoundingSet the systemd service is not capable of loading (actually searching for) all permissions in the /etc/usbguard/rules.d folder. Adding CAP_DAC_READ_SEARCH allows the daemon running in a service to load rules from the rules folder.

See Issue #654 