### PR TITLE
Extend audit detail via new key attribute in rule language. Add support for auditing implicit policy matches.

### DIFF
--- a/src/Daemon/Daemon.cpp
+++ b/src/Daemon/Daemon.cpp
@@ -71,7 +71,8 @@ namespace usbguard
     "IPCAccessControlFiles",
     "AuditFilePath",
     "AuditBackend",
-    "HidePII"
+    "HidePII",
+    "RuleSourceLogging"
   };
 
   static const std::vector<std::pair<std::string, Daemon::DevicePolicyMethod>> device_policy_method_strings = {
@@ -125,6 +126,7 @@ namespace usbguard
     _inserted_device_policy_method = DevicePolicyMethod::ApplyPolicy;
     _device_rules_with_port = false;
     _restore_controller_device_state = false;
+    _rule_source = false;
     pid_fd = -1;
   }
 
@@ -393,6 +395,22 @@ namespace usbguard
       }
       else if (value != "false") {
         throw Exception("Configuration", "HidePII", "Invalid value");
+      }
+    }
+
+    /* RuleSourceLogging */
+    if (_config.hasSettingValue("RuleSourceLogging")) {
+      const std::string value = _config.getSettingValue("RuleSourceLogging");
+      USBGUARD_LOG(Debug) << "Setting RuleSourceLogging to " << value;
+
+      if (value == "true") {
+        _rule_source = true;
+      }
+      else if (value == "false") {
+        _rule_source = false;
+      }
+      else {
+        throw Exception("Configuration", "RuleSourceLogging", "Invalid value");
       }
     }
 
@@ -862,9 +880,26 @@ namespace usbguard
     USBGUARD_LOG(Trace) << "device_ptr=" << device.get()
       << " matched_rule_ptr=" << matched_rule.get();
 
-    auto audit_event = (matched_rule->isKey()) 
-      ? _audit.policyEvent(device, device->getTarget(), matched_rule->getTarget(), matched_rule->getKey())
-      : _audit.policyEvent(device, device->getTarget(), matched_rule->getTarget());
+    auto audit_event = [&]() {
+      if (_rule_source){
+        if (matched_rule->getRuleID() == Rule::ImplicitID) {
+          return _audit.policyEventSource(device, device->getTarget(), matched_rule->getTarget(), RULE_TYPE_IMPLICIT);
+        }
+        
+        if (matched_rule->hasKey()){
+          return _audit.policyEventSourceKey(device, device->getTarget(), matched_rule->getTarget(), RULE_TYPE_LOOKUP, matched_rule->getKey());
+        }
+        
+        return _audit.policyEventSource(device, device->getTarget(), matched_rule->getTarget(), RULE_TYPE_LOOKUP); 
+      }
+      
+      if (matched_rule->hasKey()){
+        return _audit.policyEventKey(device, device->getTarget(), matched_rule->getTarget(), matched_rule->getKey());
+      }
+
+      return _audit.policyEvent(device, device->getTarget(), matched_rule->getTarget());  
+
+    }();
 
     const Rule::Target target_old = device->getTarget();
     std::shared_ptr<Device> device_post = \

--- a/src/Daemon/Daemon.cpp
+++ b/src/Daemon/Daemon.cpp
@@ -861,7 +861,11 @@ namespace usbguard
   {
     USBGUARD_LOG(Trace) << "device_ptr=" << device.get()
       << " matched_rule_ptr=" << matched_rule.get();
-    auto audit_event = _audit.policyEvent(device, device->getTarget(), matched_rule->getTarget());
+
+    auto audit_event = (matched_rule->isKey()) 
+      ? _audit.policyEvent(device, device->getTarget(), matched_rule->getTarget(), matched_rule->getKey())
+      : _audit.policyEvent(device, device->getTarget(), matched_rule->getTarget());
+
     const Rule::Target target_old = device->getTarget();
     std::shared_ptr<Device> device_post = \
       _dm->applyDevicePolicy(device->getID(),

--- a/src/Daemon/Daemon.hpp
+++ b/src/Daemon/Daemon.hpp
@@ -135,6 +135,10 @@ namespace usbguard
 
     bool _device_rules_with_port;
     bool _restore_controller_device_state;
+    bool _rule_source;
+
+    static inline const std::string RULE_TYPE_LOOKUP = "lookup";
+    static inline const std::string RULE_TYPE_IMPLICIT = "implicit";
 
     AuditIdentity _audit_identity;
     Audit _audit;

--- a/src/Library/RuleParser/Actions.hpp
+++ b/src/Library/RuleParser/Actions.hpp
@@ -91,7 +91,7 @@ namespace usbguard
         }
       }
     };
-
+    
     static const std::string stringValueFromRule(const std::string& value)
     {
       const std::string string_raw(value.substr(1, value.size() - 2));
@@ -523,6 +523,24 @@ namespace usbguard
         }
       }
     };
+
+    template<typename Rule>
+    struct key_actions : tao::pegtl::nothing<Rule> {};
+
+    template<>
+    struct key_actions<string_value> {
+      template<typename Input>
+      static void apply(const Input& in, Rule& rule)
+      {
+        try {
+          rule.setKey(stringValueFromRule(in.string()));
+        }
+        catch (const std::exception& ex) {
+          throw tao::pegtl::parse_error(ex.what(), in);
+        }
+      }
+    };
+
   } /* namespace RuleParser */
 } /* namespace usbguard */
 

--- a/src/Library/RuleParser/Actions.hpp
+++ b/src/Library/RuleParser/Actions.hpp
@@ -91,7 +91,7 @@ namespace usbguard
         }
       }
     };
-    
+
     static const std::string stringValueFromRule(const std::string& value)
     {
       const std::string string_raw(value.substr(1, value.size() - 2));

--- a/src/Library/RuleParser/Grammar.hpp
+++ b/src/Library/RuleParser/Grammar.hpp
@@ -76,12 +76,14 @@ namespace usbguard
 
     struct str_match_all: TAO_PEGTL_STRING("match-all") {};
 
+    struct str_key: TAO_PEGTL_STRING("key") {};
+
     /*
      * Generic rule attribute
      */
     struct multiset_operator
       : sor<str_all_of, str_one_of, str_none_of, str_equals_ordered, str_equals, str_match_all> {};
-
+    
     template<class attribute_value_rule>
     struct attribute_value_multiset
       : seq<opt<multiset_operator, plus<ascii::blank>>,
@@ -91,7 +93,7 @@ namespace usbguard
 
     template<class attribute_identifier, class attribute_value_rule>
     struct rule_attribute
-      : seq<attribute_identifier, plus<ascii::blank>,
+      : seq<attribute_identifier, plus<ascii::blank>, 
         sor<attribute_value_multiset<attribute_value_rule>,
         attribute_value_rule>> {};
 
@@ -226,12 +228,24 @@ namespace usbguard
         star<seq<not_at<eof>, any>>>> {};
 
     /*
+     * Rule key
+     */
+    struct key_logic
+      : action<key_actions, string_value> {};
+
+    struct key
+      : seq<str_key,
+        plus<ascii::blank>,
+        key_logic> {};
+
+    /*
      * Rule
      */
     struct rule
       : seq<target,
         opt<plus<ascii::blank>, device_id>,
         opt<plus<ascii::blank>, list<rule_attributes, plus<ascii::blank>>>,
+        opt<plus<ascii::blank>, key>,
         opt<comment>,
         star<ascii::blank>> {};
 

--- a/src/Library/RuleParser/Grammar.hpp
+++ b/src/Library/RuleParser/Grammar.hpp
@@ -83,7 +83,7 @@ namespace usbguard
      */
     struct multiset_operator
       : sor<str_all_of, str_one_of, str_none_of, str_equals_ordered, str_equals, str_match_all> {};
-    
+
     template<class attribute_value_rule>
     struct attribute_value_multiset
       : seq<opt<multiset_operator, plus<ascii::blank>>,

--- a/src/Library/RulePrivate.cpp
+++ b/src/Library/RulePrivate.cpp
@@ -39,7 +39,8 @@ namespace usbguard
       _via_port("via-port"),
       _with_interface("with-interface"),
       _conditions("if"),
-      _label("label")
+      _label("label"),
+      _key("key")
   {
     _rule_id = Rule::DefaultID;
     _target = Rule::Target::Invalid;
@@ -56,7 +57,8 @@ namespace usbguard
       _via_port("via-port"),
       _with_interface("with-interface"),
       _conditions("if"),
-      _label("label")
+      _label("label"),
+      _key("key")
   {
     *this = rhs;
   }
@@ -263,6 +265,21 @@ namespace usbguard
     return _serial.get();
   }
 
+  void RulePrivate::setKey(const std::string& value)
+  {
+    _key.set(value);
+  }
+
+  const std::string& RulePrivate::getKey() const
+  {
+    return _key.get();
+  }
+
+  bool RulePrivate::isKey() const
+  {
+    return !_key.empty();
+  }
+
   const Rule::Attribute<std::string>& RulePrivate::attributeSerial() const
   {
     return _serial;
@@ -425,7 +442,7 @@ namespace usbguard
     return;
   }
 
-  std::string RulePrivate::toString(bool invalid, bool hide_pii) const
+  std::string RulePrivate::toString(bool invalid, bool hide_pii, bool hide_key) const
   {
     std::string rule_string;
 
@@ -459,6 +476,11 @@ namespace usbguard
     toString_appendNonEmptyAttribute(rule_string, _conditions);
     toString_appendNonEmptyAttribute(rule_string, _with_connect_type);
     toString_appendNonEmptyAttribute(rule_string, _label);
+
+    if (!hide_key) {
+      toString_appendNonEmptyAttribute(rule_string, _key);
+    }
+    
     return rule_string;
   }
 

--- a/src/Library/RulePrivate.cpp
+++ b/src/Library/RulePrivate.cpp
@@ -476,7 +476,7 @@ namespace usbguard
     toString_appendNonEmptyAttribute(rule_string, _conditions);
     toString_appendNonEmptyAttribute(rule_string, _with_connect_type);
     toString_appendNonEmptyAttribute(rule_string, _label);
-    
+
     return rule_string;
   }
 

--- a/src/Library/RulePrivate.cpp
+++ b/src/Library/RulePrivate.cpp
@@ -275,7 +275,7 @@ namespace usbguard
     return _key.get();
   }
 
-  bool RulePrivate::isKey() const
+  bool RulePrivate::hasKey() const
   {
     return !_key.empty();
   }
@@ -442,7 +442,7 @@ namespace usbguard
     return;
   }
 
-  std::string RulePrivate::toString(bool invalid, bool hide_pii, bool hide_key) const
+  std::string RulePrivate::toString(bool invalid, bool hide_pii) const
   {
     std::string rule_string;
 
@@ -476,10 +476,6 @@ namespace usbguard
     toString_appendNonEmptyAttribute(rule_string, _conditions);
     toString_appendNonEmptyAttribute(rule_string, _with_connect_type);
     toString_appendNonEmptyAttribute(rule_string, _label);
-
-    if (!hide_key) {
-      toString_appendNonEmptyAttribute(rule_string, _key);
-    }
     
     return rule_string;
   }

--- a/src/Library/RulePrivate.hpp
+++ b/src/Library/RulePrivate.hpp
@@ -113,7 +113,7 @@ namespace usbguard
 
     void setKey(const std::string& value);
     const std::string& getKey() const;
-    bool isKey() const;
+    bool hasKey() const;
 
     /*
      * Set/get for a single value isn't useful for the
@@ -127,7 +127,7 @@ namespace usbguard
     const Rule::Attribute<RuleCondition>& attributeConditions() const;
     Rule::Attribute<RuleCondition>& attributeConditions();
 
-    std::string toString(bool invalid = false, bool hide_pii = false, bool hide_key = true) const;
+    std::string toString(bool invalid = false, bool hide_pii = false) const;
 
     MetaData& metadata();
     const MetaData& metadata() const;

--- a/src/Library/RulePrivate.hpp
+++ b/src/Library/RulePrivate.hpp
@@ -111,6 +111,10 @@ namespace usbguard
     const Rule::Attribute<std::string>& attributeViaPort() const;
     Rule::Attribute<std::string>& attributeViaPort();
 
+    void setKey(const std::string& value);
+    const std::string& getKey() const;
+    bool isKey() const;
+
     /*
      * Set/get for a single value isn't useful for the
      * with-interface attribute as it usualy contains
@@ -123,7 +127,7 @@ namespace usbguard
     const Rule::Attribute<RuleCondition>& attributeConditions() const;
     Rule::Attribute<RuleCondition>& attributeConditions();
 
-    std::string toString(bool invalid = false, bool hide_pii = false) const;
+    std::string toString(bool invalid = false, bool hide_pii = false, bool hide_key = true) const;
 
     MetaData& metadata();
     const MetaData& metadata() const;
@@ -146,6 +150,7 @@ namespace usbguard
     Rule::Attribute<USBInterfaceType> _with_interface;
     Rule::Attribute<RuleCondition> _conditions;
     Rule::Attribute<std::string> _label;
+    Rule::Attribute<std::string> _key;
     uint64_t _conditions_state;
   };
 }

--- a/src/Library/public/usbguard/Audit.cpp
+++ b/src/Library/public/usbguard/Audit.cpp
@@ -190,9 +190,22 @@ namespace usbguard
     return policyEvent(_identity, device, old_target, new_target);
   }
 
-  AuditEvent Audit::policyEvent(std::shared_ptr<Device> device, Rule::Target old_target, Rule::Target new_target, std::string matched_rule_key)
+  AuditEvent Audit::policyEventKey(std::shared_ptr<Device> device, Rule::Target old_target, Rule::Target new_target, 
+    std::string matched_rule_key)
   {
-    return policyEvent(_identity, device, old_target, new_target, matched_rule_key);
+    return policyEventKey(_identity, device, old_target, new_target, matched_rule_key);
+  }
+
+  AuditEvent Audit::policyEventSource(std::shared_ptr<Device> device, Rule::Target old_target, Rule::Target new_target, 
+    std::string rule_source)
+  {
+    return policyEventSource(_identity, device, old_target, new_target, rule_source);
+  }
+
+  AuditEvent Audit::policyEventSourceKey(std::shared_ptr<Device> device, Rule::Target old_target, Rule::Target new_target, 
+    std::string rule_source, std::string matched_rule_key)
+  {
+    return policyEventSourceKey(_identity, device, old_target, new_target, rule_source, matched_rule_key);
   }
 
   AuditEvent Audit::deviceEvent(std::shared_ptr<Device> device, DeviceManager::EventType event)
@@ -246,7 +259,7 @@ namespace usbguard
     return event;
   }
 
-  AuditEvent Audit::policyEvent(const AuditIdentity& identity, std::shared_ptr<Device> device, Rule::Target old_target,
+  AuditEvent Audit::policyEventKey(const AuditIdentity& identity, std::shared_ptr<Device> device, Rule::Target old_target,
     Rule::Target new_target, std::string matched_rule_key)
   {
     AuditEvent event(identity, _backend);
@@ -255,7 +268,34 @@ namespace usbguard
     event.setKey("target.new", Rule::targetToString(new_target));
     event.setKey("device.system_name", device->getSystemName());
     event.setKey("device.rule", device->getDeviceRule()->toString(false, _hide_pii));
-    event.setKey("matched.rule.key", matched_rule_key);
+    event.setKey("rule.key", matched_rule_key);
+    return event;
+  }
+
+  AuditEvent Audit::policyEventSource(const AuditIdentity& identity, std::shared_ptr<Device> device, Rule::Target old_target,
+    Rule::Target new_target, std::string rule_source)
+  {
+    AuditEvent event(identity, _backend);
+    event.setKey("type", std::string("Policy.Device.") + Policy::eventTypeToString(Policy::EventType::Update));
+    event.setKey("target.old", Rule::targetToString(old_target));
+    event.setKey("target.new", Rule::targetToString(new_target));
+    event.setKey("device.system_name", device->getSystemName());
+    event.setKey("device.rule", device->getDeviceRule()->toString(false, _hide_pii));
+    event.setKey("rule.source", rule_source);
+    return event;
+  }
+
+  AuditEvent Audit::policyEventSourceKey(const AuditIdentity& identity, std::shared_ptr<Device> device, Rule::Target old_target,
+    Rule::Target new_target, std::string rule_source, std::string matched_rule_key)
+  {
+    AuditEvent event(identity, _backend);
+    event.setKey("type", std::string("Policy.Device.") + Policy::eventTypeToString(Policy::EventType::Update));
+    event.setKey("target.old", Rule::targetToString(old_target));
+    event.setKey("target.new", Rule::targetToString(new_target));
+    event.setKey("device.system_name", device->getSystemName());
+    event.setKey("device.rule", device->getDeviceRule()->toString(false, _hide_pii));
+    event.setKey("rule.source", rule_source);
+    event.setKey("rule.key", matched_rule_key);
     return event;
   }
 

--- a/src/Library/public/usbguard/Audit.cpp
+++ b/src/Library/public/usbguard/Audit.cpp
@@ -190,6 +190,11 @@ namespace usbguard
     return policyEvent(_identity, device, old_target, new_target);
   }
 
+  AuditEvent Audit::policyEvent(std::shared_ptr<Device> device, Rule::Target old_target, Rule::Target new_target, std::string matched_rule_key)
+  {
+    return policyEvent(_identity, device, old_target, new_target, matched_rule_key);
+  }
+
   AuditEvent Audit::deviceEvent(std::shared_ptr<Device> device, DeviceManager::EventType event)
   {
     return deviceEvent(_identity, device, event);
@@ -238,6 +243,19 @@ namespace usbguard
     event.setKey("target.new", Rule::targetToString(new_target));
     event.setKey("device.system_name", device->getSystemName());
     event.setKey("device.rule", device->getDeviceRule()->toString(false, _hide_pii));
+    return event;
+  }
+
+  AuditEvent Audit::policyEvent(const AuditIdentity& identity, std::shared_ptr<Device> device, Rule::Target old_target,
+    Rule::Target new_target, std::string matched_rule_key)
+  {
+    AuditEvent event(identity, _backend);
+    event.setKey("type", std::string("Policy.Device.") + Policy::eventTypeToString(Policy::EventType::Update));
+    event.setKey("target.old", Rule::targetToString(old_target));
+    event.setKey("target.new", Rule::targetToString(new_target));
+    event.setKey("device.system_name", device->getSystemName());
+    event.setKey("device.rule", device->getDeviceRule()->toString(false, _hide_pii));
+    event.setKey("matched.rule.key", matched_rule_key);
     return event;
   }
 

--- a/src/Library/public/usbguard/Audit.hpp
+++ b/src/Library/public/usbguard/Audit.hpp
@@ -373,6 +373,38 @@ namespace usbguard
      */
     AuditEvent policyEvent(std::shared_ptr<Device> device, Rule::Target old_target, Rule::Target new_target);
 
+   /**
+     * @brief Constructs new \link AuditEvent AuditEvent\endlink for given
+     * policy \link Policy::EventType event\endlink.
+     *
+     * Sets audit event keys:
+     *   - type\=Policy\.Device\.Update
+     *   - target\.old\=\<old rule target\>
+     *   - target\.new\=\<new rule target\>
+     *   - device\.system_name\=<device system name\>
+     *   - device\.rule\=\<device rule\>
+     *   - matched\.rule\.key\=\<rule key\>
+     *
+     * Audit policy changes:
+     *   - rule append
+     *   - rule remove
+     *   - rule update
+     *   - policy parameter change
+     *
+     * Audit data:
+     *   - who: uid + pid
+     *   - when: time
+     *   - what: append, remove, update
+     *   - update: old, new
+     *
+     * @param device Device where the rule target has changed.
+     * @param old_target Old rule target.
+     * @param new_target New rule target.
+     * @param matched_rule_key Key of the new rule.
+     * @return \link AuditEvent Audit event\endlink.
+     */
+    AuditEvent policyEvent(std::shared_ptr<Device> device, Rule::Target old_target, Rule::Target new_target, std::string matched_rule_key);
+
     /**
      * @brief Constructs new \link AuditEvent AuditEvent\endlink for given
      * device \link DeviceManager::EventType event\endlink.
@@ -543,6 +575,40 @@ namespace usbguard
      */
     AuditEvent policyEvent(const AuditIdentity& identity, std::shared_ptr<Device> device, Rule::Target old_target,
       Rule::Target new_target);
+
+    /**
+     * @brief Constructs new \link AuditEvent AuditEvent\endlink for given
+     * policy \link Policy::EventType event\endlink.
+     *
+     * Sets audit event keys:
+     *   - type\=Policy\.Device\.Update
+     *   - target\.old\=\<old rule target\>
+     *   - target\.new\=\<new rule target\>
+     *   - device\.system_name\=\<device system name\>
+     *   - device\.rule\=\<device rule\>
+     *   - matched\.rule\.key\=\<rule key\>
+     *
+     * Audit policy changes:
+     *   - rule append
+     *   - rule remove
+     *   - rule update
+     *   - policy parameter change
+     *
+     * Audit data:
+     *   - who: uid + pid
+     *   - when: time
+     *   - what: append, remove, update
+     *   - update: old, new
+     *
+     * @param identity Audit identity.
+     * @param device Device where the rule target has changed.
+     * @param old_target Old rule target.
+     * @param new_target New rule target.
+     * @param matched_rule_key New rule key.
+     * @return \link AuditEvent Audit event\endlink.
+     */
+    AuditEvent policyEvent(const AuditIdentity& identity, std::shared_ptr<Device> device, Rule::Target old_target,
+      Rule::Target new_target, std::string matched_rule_key);
 
     /**
      * @brief Constructs new \link AuditEvent AuditEvent\endlink for given

--- a/src/Library/public/usbguard/Audit.hpp
+++ b/src/Library/public/usbguard/Audit.hpp
@@ -383,7 +383,7 @@ namespace usbguard
      *   - target\.new\=\<new rule target\>
      *   - device\.system_name\=<device system name\>
      *   - device\.rule\=\<device rule\>
-     *   - matched\.rule\.key\=\<rule key\>
+     *   - rule\.key\=\<rule key\>
      *
      * Audit policy changes:
      *   - rule append
@@ -403,7 +403,78 @@ namespace usbguard
      * @param matched_rule_key Key of the new rule.
      * @return \link AuditEvent Audit event\endlink.
      */
-    AuditEvent policyEvent(std::shared_ptr<Device> device, Rule::Target old_target, Rule::Target new_target, std::string matched_rule_key);
+    AuditEvent policyEventKey(std::shared_ptr<Device> device, Rule::Target old_target, Rule::Target new_target, 
+      std::string matched_rule_key);
+    
+
+    /**
+     * @brief Constructs new \link AuditEvent AuditEvent\endlink for given
+     * policy \link Policy::EventType event\endlink.
+     *
+     * Sets audit event keys:
+     *   - type\=Policy\.Device\.Update
+     *   - target\.old\=\<old rule target\>
+     *   - target\.new\=\<new rule target\>
+     *   - device\.system_name\=<device system name\>
+     *   - device\.rule\=\<device rule\>
+     *   - rule\.source\=\<rule source\>
+     *
+     * Audit policy changes:
+     *   - rule append
+     *   - rule remove
+     *   - rule update
+     *   - policy parameter change
+     *
+     * Audit data:
+     *   - who: uid + pid
+     *   - when: time
+     *   - what: append, remove, update
+     *   - update: old, new
+     *
+     * @param device Device where the rule target has changed.
+     * @param old_target Old rule target.
+     * @param new_target New rule target.
+     * @param rule_source From where the matched rule is defined.
+     * @return \link AuditEvent Audit event\endlink.
+     */
+    AuditEvent policyEventSource(std::shared_ptr<Device> device, Rule::Target old_target, Rule::Target new_target, 
+      std::string rule_source);
+    
+
+    /**
+     * @brief Constructs new \link AuditEvent AuditEvent\endlink for given
+     * policy \link Policy::EventType event\endlink.
+     *
+     * Sets audit event keys:
+     *   - type\=Policy\.Device\.Update
+     *   - target\.old\=\<old rule target\>
+     *   - target\.new\=\<new rule target\>
+     *   - device\.system_name\=<device system name\>
+     *   - device\.rule\=\<device rule\>
+     *   - rule\.source\=\<rule source\>
+     *   - rule\.key\=\<rule key\>
+     *
+     * Audit policy changes:
+     *   - rule append
+     *   - rule remove
+     *   - rule update
+     *   - policy parameter change
+     *
+     * Audit data:
+     *   - who: uid + pid
+     *   - when: time
+     *   - what: append, remove, update
+     *   - update: old, new
+     *
+     * @param device Device where the rule target has changed.
+     * @param old_target Old rule target.
+     * @param new_target New rule target.
+     * @param rule_source From where the matched rule is defined.
+     * @param matched_rule_key Key of the new rule.
+     * @return \link AuditEvent Audit event\endlink.
+     */
+    AuditEvent policyEventSourceKey(std::shared_ptr<Device> device, Rule::Target old_target, Rule::Target new_target, 
+      std::string rule_source, std::string matched_rule_key);
 
     /**
      * @brief Constructs new \link AuditEvent AuditEvent\endlink for given
@@ -607,9 +678,79 @@ namespace usbguard
      * @param matched_rule_key New rule key.
      * @return \link AuditEvent Audit event\endlink.
      */
-    AuditEvent policyEvent(const AuditIdentity& identity, std::shared_ptr<Device> device, Rule::Target old_target,
+    AuditEvent policyEventKey(const AuditIdentity& identity, std::shared_ptr<Device> device, Rule::Target old_target,
       Rule::Target new_target, std::string matched_rule_key);
 
+    /**
+     * @brief Constructs new \link AuditEvent AuditEvent\endlink for given
+     * policy \link Policy::EventType event\endlink.
+     *
+     * Sets audit event keys:
+     *   - type\=Policy\.Device\.Update
+     *   - target\.old\=\<old rule target\>
+     *   - target\.new\=\<new rule target\>
+     *   - device\.system_name\=<device system name\>
+     *   - device\.rule\=\<device rule\>
+     *   - rule\.source\=\<rule source\>
+     *
+     * Audit policy changes:
+     *   - rule append
+     *   - rule remove
+     *   - rule update
+     *   - policy parameter change
+     *
+     * Audit data:
+     *   - who: uid + pid
+     *   - when: time
+     *   - what: append, remove, update
+     *   - update: old, new
+     *
+     * @param identity Audit identity.
+     * @param device Device where the rule target has changed.
+     * @param old_target Old rule target.
+     * @param new_target New rule target.
+     * @param rule_source From where the matched rule is defined.
+     * @return \link AuditEvent Audit event\endlink.
+     */
+    AuditEvent policyEventSource(const AuditIdentity& identity, std::shared_ptr<Device> device, Rule::Target old_target,
+      Rule::Target new_target, std::string rule_source);
+    
+    /**
+     * @brief Constructs new \link AuditEvent AuditEvent\endlink for given
+     * policy \link Policy::EventType event\endlink.
+     *
+     * Sets audit event keys:
+     *   - type\=Policy\.Device\.Update
+     *   - target\.old\=\<old rule target\>
+     *   - target\.new\=\<new rule target\>
+     *   - device\.system_name\=<device system name\>
+     *   - device\.rule\=\<device rule\>
+     *   - rule\.source\=\<rule source\>
+     *   - rule\.key\=\<rule key\>
+     *
+     * Audit policy changes:
+     *   - rule append
+     *   - rule remove
+     *   - rule update
+     *   - policy parameter change
+     *
+     * Audit data:
+     *   - who: uid + pid
+     *   - when: time
+     *   - what: append, remove, update
+     *   - update: old, new
+     *
+     * @param identity Audit identity.
+     * @param device Device where the rule target has changed.
+     * @param old_target Old rule target.
+     * @param new_target New rule target.
+     * @param rule_source From where the matched rule is defined.
+     * @param matched_rule_key Key of the new rule.
+     * @return \link AuditEvent Audit event\endlink.
+     */
+    AuditEvent policyEventSourceKey(const AuditIdentity& identity, std::shared_ptr<Device> device, Rule::Target old_target,
+      Rule::Target new_target, std::string rule_source, std::string matched_rule_key);
+    
     /**
      * @brief Constructs new \link AuditEvent AuditEvent\endlink for given
      * device \link DeviceManager::EventType event\endlink.

--- a/src/Library/public/usbguard/Rule.cpp
+++ b/src/Library/public/usbguard/Rule.cpp
@@ -116,9 +116,9 @@ namespace usbguard
     return d_pointer->getKey();
   }
 
-  bool Rule::isKey() const
+  bool Rule::hasKey() const
   {
-    return d_pointer->isKey();
+    return d_pointer->hasKey();
   }
 
   const Rule::Attribute<std::string>& Rule::attributeSerial() const
@@ -299,9 +299,9 @@ namespace usbguard
         getTarget() == Target::Empty);
   }
 
-  std::string Rule::toString(bool invalid, bool hide_serial, bool hide_key) const
+  std::string Rule::toString(bool invalid, bool hide_serial) const
   {
-    return d_pointer->toString(invalid, hide_serial, hide_key);
+    return d_pointer->toString(invalid, hide_serial);
   }
 
   void Rule::updateMetaDataCounters(bool applied, bool evaluated)

--- a/src/Library/public/usbguard/Rule.cpp
+++ b/src/Library/public/usbguard/Rule.cpp
@@ -106,6 +106,21 @@ namespace usbguard
     return d_pointer->getSerial();
   }
 
+  void Rule::setKey(const std::string& value)
+  {
+    d_pointer->setKey(value);
+  }
+
+  const std::string& Rule::getKey() const
+  {
+    return d_pointer->getKey();
+  }
+
+  bool Rule::isKey() const
+  {
+    return d_pointer->isKey();
+  }
+
   const Rule::Attribute<std::string>& Rule::attributeSerial() const
   {
     return d_pointer->attributeSerial();
@@ -284,9 +299,9 @@ namespace usbguard
         getTarget() == Target::Empty);
   }
 
-  std::string Rule::toString(bool invalid, bool hide_serial) const
+  std::string Rule::toString(bool invalid, bool hide_serial, bool hide_key) const
   {
-    return d_pointer->toString(invalid, hide_serial);
+    return d_pointer->toString(invalid, hide_serial, hide_key);
   }
 
   void Rule::updateMetaDataCounters(bool applied, bool evaluated)

--- a/src/Library/public/usbguard/Rule.hpp
+++ b/src/Library/public/usbguard/Rule.hpp
@@ -840,7 +840,7 @@ namespace usbguard
      *
      * @return Rule key status.
      */
-    bool isKey() const;
+    bool hasKey() const;
 
     /**
      * @brief Returns imutable serial number attribute.
@@ -1136,7 +1136,7 @@ namespace usbguard
      * identifiable information) will not be included in the string.
      * @return String representation of this rule.
      */
-    std::string toString(bool invalid = false, bool hide_serial = false, bool hide_key = true) const;
+    std::string toString(bool invalid = false, bool hide_serial = false) const;
 
     /**
      * @brief Updates meta-data last applied and last evaluated counters.

--- a/src/Library/public/usbguard/Rule.hpp
+++ b/src/Library/public/usbguard/Rule.hpp
@@ -820,6 +820,29 @@ namespace usbguard
     const std::string& getSerial() const;
 
     /**
+     * @brief Sets key attribute.
+     *
+     * @param value Key to set.
+     * @see \link Attribute::set() set()\endlink
+     */
+    void setKey(const std::string& value);
+
+    /**
+     * @brief Returns key.
+     *
+     * @return Rule key.
+     * @see \link Attribute::get() get()\endlink
+     */
+    const std::string& getKey() const;
+
+    /**
+     * @brief Returns true if the Rule has a key.
+     *
+     * @return Rule key status.
+     */
+    bool isKey() const;
+
+    /**
      * @brief Returns imutable serial number attribute.
      *
      * @return Imutable serial number attribute.
@@ -1113,7 +1136,7 @@ namespace usbguard
      * identifiable information) will not be included in the string.
      * @return String representation of this rule.
      */
-    std::string toString(bool invalid = false, bool hide_serial = false) const;
+    std::string toString(bool invalid = false, bool hide_serial = false, bool hide_key = true) const;
 
     /**
      * @brief Updates meta-data last applied and last evaluated counters.

--- a/usbguard-daemon.conf.in
+++ b/usbguard-daemon.conf.in
@@ -213,3 +213,12 @@ AuditFilePath=%localstatedir%/log/usbguard/usbguard-audit.log
 # hashes of descriptors (which include the serial number) from audit entries.
 #
 HidePII=false
+
+#
+# When logging policy events, enable differentiation between implicit policy 
+# events and defined rules.
+#
+# * true  - show rule source in logs
+# * false - hide rule source in logs
+#
+RuleSourceLogging=false


### PR DESCRIPTION
Hello all

New features in this pull request:
- A new rule language option that allows policy events to display the matched rule in audit logs
- A new option in usbguard-daemon.conf that enables differentiation between implicit and explicit policy rule events (in audit logs)

By extending the rule language to allow an optional key, you can more easily audit systems to see which policy events are triggered by which rule. This could allow admins to have a greater visibility of the systems they are trying to secure.

Furthermore,  you can enable the new "RuleSourceLogging" option inside usbguard-daemon.conf and logs will differentiate between implicit and explicit policy events.

Thank you
Alex