### PR TITLE
Initialize the default policy target

### DIFF
--- a/src/Library/public/usbguard/Policy.cpp
+++ b/src/Library/public/usbguard/Policy.cpp
@@ -26,7 +26,7 @@
 
 namespace usbguard
 {
-  Policy::Policy()
+  Policy::Policy(): _defaultTarget(Rule::Target::Block)
   {
     _rulesets_ptr = std::vector<std::shared_ptr<RuleSet>>();
   }


### PR DESCRIPTION
The Policy constructor leaves _defaultTarget uninitialized. Calling getDefaultTarget() before setDefaultTarget() reads an indeterminate value.

Initialize _defaultTarget to Rule::Target::Block in the constructor to ensure a defined default policy.